### PR TITLE
feature/JIRA-71-create-quiz-mutations

### DIFF
--- a/apps/api/src/graphql/mutations/index.ts
+++ b/apps/api/src/graphql/mutations/index.ts
@@ -5,5 +5,6 @@ import "./skillTree.mutations";
 import "./skillNode.structural.mutations";
 import "./skillNode.delete.simple.mutations";
 import "./skillNode.delete.advanced.mutations";
+import "./quiz.mutations";
 
 // Import mutations/*.ts files here

--- a/apps/api/src/graphql/mutations/quiz.mutations.ts
+++ b/apps/api/src/graphql/mutations/quiz.mutations.ts
@@ -1,0 +1,105 @@
+import { builder } from "@graphql/builder";
+import { requireAdmin } from "@graphql/auth/requireAuth";
+import { Prisma } from "@prisma/client";
+import { assertNodeOwnership } from "@graphql/auth/permissions";
+import { GraphQLError } from "graphql";
+import { updateOneSkillNodeMutationArgs } from "@graphql/__generated__/SkillNode/mutations/updateOne.base";
+
+builder.mutationFields((t) => ({
+  createQuiz: t.prismaField({
+    type: "Quiz",
+    args: {
+      nodeId: t.arg.string({ required: true }), //should be the same value as SkillNode ID
+      title: t.arg.string({ required: true }),
+      required: t.arg.boolean({ required: true }),
+    },
+    resolve: async (query, _root, { nodeId, title, required }, ctx) => {
+      ctx.auth.requireAuth();
+      requireAdmin(ctx);
+
+      await assertNodeOwnership(ctx, nodeId); //ensures that the user owns the current node
+
+      const quiz = await ctx.prisma.quiz.create({
+        ...query,
+        data: {
+          nodeId: nodeId,
+          title: title,
+          required: required,
+        },
+        include: {
+          questions: { include: { options: true } },
+        },
+      });
+
+      return quiz;
+    },
+  }),
+
+  updateQuiz: t.prismaField({
+    type: "Quiz",
+    args: {
+      id: t.arg.id({ required: true }),
+      title: t.arg.string(),
+      required: t.arg.boolean(),
+    },
+    resolve: async (query, _root, { id, title, required }, ctx) => {
+      ctx.auth.requireAuth();
+      requireAdmin(ctx);
+
+      const existing = await ctx.prisma.quiz.findUnique({
+        where: { id },
+        select: {
+          nodeId: true,
+        },
+      });
+
+      if (!existing) {
+        throw new GraphQLError("Quiz not found");
+      }
+
+      await assertNodeOwnership(ctx, existing.nodeId);
+
+      const quiz = await ctx.prisma.quiz.update({
+        ...query,
+        where: { id },
+        data: {
+          ...(title !== undefined && title !== null && { title }),
+          ...(required !== undefined && required !== null && { required }),
+          updatedAt: new Date(),
+        },
+        include: { questions: { include: { options: true } } },
+      });
+
+      return quiz;
+    },
+  }),
+
+  deleteQuiz: t.prismaField({
+    type: "Quiz",
+    args: { id: t.arg.id({ required: true }) },
+    resolve: async (query, _root, { id }, ctx) => {
+      ctx.auth.requireAuth();
+      requireAdmin(ctx);
+
+      const existing = await ctx.prisma.quiz.findUnique({
+        where: { id },
+        select: {
+          nodeId: true,
+        },
+      });
+
+      if (!existing) {
+        throw new GraphQLError("Quiz not found");
+      }
+
+      await assertNodeOwnership(ctx, existing.nodeId);
+
+      const deleted = await ctx.prisma.quiz.delete({
+        ...query,
+        where: { id },
+      });
+
+      return deleted;
+    },
+  }),
+}));

--- a/apps/api/src/graphql/mutations/quiz.mutations.ts
+++ b/apps/api/src/graphql/mutations/quiz.mutations.ts
@@ -1,9 +1,7 @@
 import { builder } from "@graphql/builder";
 import { requireAdmin } from "@graphql/auth/requireAuth";
-import { Prisma } from "@prisma/client";
 import { assertNodeOwnership } from "@graphql/auth/permissions";
 import { GraphQLError } from "graphql";
-import { updateOneSkillNodeMutationArgs } from "@graphql/__generated__/SkillNode/mutations/updateOne.base";
 
 builder.mutationFields((t) => ({
   createQuiz: t.prismaField({
@@ -25,9 +23,6 @@ builder.mutationFields((t) => ({
           nodeId: nodeId,
           title: title,
           required: required,
-        },
-        include: {
-          questions: { include: { options: true } },
         },
       });
 
@@ -65,9 +60,7 @@ builder.mutationFields((t) => ({
         data: {
           ...(title !== undefined && title !== null && { title }),
           ...(required !== undefined && required !== null && { required }),
-          updatedAt: new Date(),
         },
-        include: { questions: { include: { options: true } } },
       });
 
       return quiz;
@@ -98,6 +91,18 @@ builder.mutationFields((t) => ({
         ...query,
         where: { id },
       });
+
+      /* The code below is for soft deleting quizzes, but I decided not to use it because nodeId needs to be a unique ID. This means that you cannot make another quiz for the same node, even after deleting. 
+      
+      const deleted = await ctx.prisma.quiz.update({
+        ...query,
+        where: { id },
+        data: {
+          deletedAt: new Date(),
+        },
+      });
+
+      */
 
       return deleted;
     },


### PR DESCRIPTION
<!--
  Welcome to Synth Tree!
  Please fill out this template completely to help reviewers understand your changes.
  Sections marked with ⚠️ are REQUIRED.
-->

## ⚠️ Jira Task

<!--
  Link to the Jira task this PR addresses.
  Format: ST-71
-->

**Jira Task ID:** ST-71
**Jira Link:** [ST-71](https://tripleten-apiary.atlassian.net/browse/ST-71?atlOrigin=eyJpIjoiZTVmMGRlNzNjMWU3NDNiNGI0YjM4N2VkMWEwOGY4OTkiLCJwIjoiaiJ9)

---

## ⚠️ Description

This pull request adds the backend request to create/edit/delete quizzes from the database. Every quiz is tied to a Skill Node (1 per node) and can only be modified by the creator of the Skill Node. 

### What changes were made?

This is a completely new script that adds three new mutations, each correlating to one of the three task of creating/editing/deleting.

### Why were these changes necessary?

This new file was necessary because quizzes are an essential part of the project and we have to make a new script to keep it organized. 

---

## ⚠️ Type of Change

<!-- Mark the type(s) of change with an [x] -->

- [x] 🎨 New Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] ♻️ Code Refactor
- [ ] ⚡ Performance Improvement
- [ ] ✅ Test Addition/Update
- [ ] 🔧 Configuration Change
- [ ] 🗑️ Code Removal

---

## ⚠️ Changes Made

<!--
  List the specific changes made in this PR
  Be detailed and specific - help reviewers understand exactly what changed
-->

Change 1: The first mutation made was the one to create quizzes. This requires a nodeId, title, and a required boolean (true/false to see if the user needs to take the quiz to move on). There are three authorization checks: First the simple authorization check to see if there is a user at all, secondly a check to see if the user is an admin, and lastly a check to see if the user owns the Skill Node. The last thing to mention is that there should be a way to add questions, but it is current untestable due to there not being any question mutations yet.

Change 2: The second mutation made was the one to edit quizzes. This only requires an id (the id of the quiz you want to edit), but you can also add the "title" and "required" fields if you wish you edit them. This mutation has the same authorization checks as the the "create" mutation, but also has an extra check to see if the quiz exists. If the user does not attach one of the optional fields of "title" and "required" it will simply keep the old value it had before. Finally, every time you update a quiz it will update the "updatedAt" field to be the current date.

Change 3: The third and final mutation was the one to delete quizzes. Just like the update mutation, this only requires an id, but there are also no optional fields. This mutation has the same authorization checks as the "update" mutation. In this mutation it simply deletes the quiz from the database. You should not be able to access the quiz after deletion.

---

## ⚠️ Testing

All testing is done within the Apollo sandbox. During testing you must always have an admin account or else none of the mutations will allow access. There is also a lot of other mutations you have to run beforehand, starting with the create course mutation and eventually ending up to creating the quiz (details in testing steps). I have tested all quiz mutations with and without the required fields, an admin and a regular user account, and with an account that didn't create the Skill Node, all of which returned the proper results. 

### Testing Steps - This is written with developers new to the sandbox in mind. 
**If you have any issues, feel free to contact me on Slack.**

Step 1: Make sure to start your database by using the command "pnpm db:start". Afterwards, navigate to the api folder.
(cd apps/api)

Step 2: Create an admin account and copy the authorization token over to the sandbox. You can find details on how to create an admin account at the file "createDevAdminUser.md". You can also add the authorization token to your sandbox environment by clicking on the gear icon next to the displayed URL. (Should be http://localhost:4000/) In this menu there should be an option add a shared header. The header key should be "authorization" and the value as "Bearer yourtoken". Ensure that you do not include the quotation marks in these fields.


Step 3: Now we're going to have to run a few mutations. Upon starting up the sandbox, it may automatically put you in the "Query" section, if so click on "Root" found under the Documentation tab. Afterwards, add a mutation and then it should give you the option to create a course. The course mutation requires the following fields: "title", "description", and "defaultTreeTitle". After adding them from the fields column on the left, you can edit the fields in the variables tab on the bottom section of the screen. Also, make sure to include the field "id" in every request from now on, because we'll need them.

After creating that, you need to create a skill tree, which can be found in the mutations tab again. This mutation requires a title and the ID of the course we just created (labeled courseId), which should've been returned in the response if you added the "id" field to that request. 

Next, we'll need to create the first Skill Node, which again can be found in the mutations tab. This mutation requires the treeId we just created and a title. 


Step 4: We can finally create our first quiz using the createQuiz mutation. This requires the nodeId we just created, a title, and a "required" boolean. For testing, you can try to create another account to try and create the quiz using the nodeId, but it won't let you because the new account isn't the owner of the node. 

Step 5: You can also edit this quiz using updateQuiz mutation and the id we just got from creating the quiz, assuming you added the id field. Other than the id, nothing else is required, but you can add the title and "required" field to edit them. Once again, it shouldn't let you edit the quiz unless you're the owner of the node.

Step 6: The last test would be to use the deleteQuiz mutation, which just gets rid of quiz completely. The only field it requires and will take is the quiz id. The same authorization checks are in this mutation as the other ones, so feel free to test and see if there is anything wrong with it.


### Test Results

Everything worked as intended when I tested it. I was able to create/update/delete the quiz as long as I was signed in the as the creator of the node. 

### Browser/Environment Tested

Chrome 144

---

## Screenshots/Videos (if applicable)

<!--
  If your changes affect the UI, add screenshots or videos here
  Before/After comparisons are especially helpful!
  You can drag and drop images directly into this text box
-->

### Before

### After

---

## ⚠️ Pre-Submission Checklist

<!--
  Review this checklist before submitting your PR
  ALL items must be checked before your PR can be merged
-->

- [x] ✅ My code follows the project's style conventions and guidelines
- [x] ✅ I have performed a self-review of my own code
- [x] ✅ I have commented my code, particularly in hard-to-understand areas
- [x] ✅ My branch is up to date with `main`
- [x] ✅ I have used descriptive commit messages
- [x] ✅ I have tested my changes thoroughly
- [x] ✅ All existing tests pass with my changes
- [x] ✅ I have added tests that prove my fix is effective or that my feature works
- [x] ✅ I have updated documentation (if needed)
- [x] ✅ My changes generate no new warnings or errors
- [x] ✅ My branch name follows the convention: `feature/ST-XXX-description` or `bugfix/ST-XXX-description`

---

## Additional Notes

<!--
  Any additional information that reviewers should know
  - Known issues or limitations
  - Future improvements planned
  - Dependencies on other PRs
  - Migration steps required
-->

My latest commit focuses on the feedback that Sara left in the review. One limitation of the way the quizzes are setup are that when you try to soft delete a quiz it doesn't let you create a new one for the Skill Node that was set for the old quiz. This is because each quiz requires a unique nodeId, but even after setting "deletedAt" that nodeId remains. NodeId also has to be an id, so I wasn't able to manually set it.

---

## Review Checklist (For Reviewers)

- [ ] Code quality and style are consistent
- [ ] Changes align with the Jira task requirements
- [ ] Tests are sufficient and passing
- [ ] Documentation is updated
- [ ] No security vulnerabilities introduced
- [ ] Performance impact is acceptable
