### PR TITLE
feature/ST-74-ImplementQuizSubmissionMutation

### DIFF
--- a/apps/api/src/graphql/mutations/quiz.mutations.ts
+++ b/apps/api/src/graphql/mutations/quiz.mutations.ts
@@ -399,7 +399,7 @@ builder.mutationFields((t) => ({
         data: {
           quizId,
           userId: ctx.user!.uid,
-          passed: false,
+          passed: false, //auto grader changes this later.
           answers: {
             create: parsedAnswers.map(({ questionId, answer }) => ({
               questionId,
@@ -410,7 +410,6 @@ builder.mutationFields((t) => ({
       });
 
       const summary = await gradeQuizAttempt(ctx.prisma, quizAttempt.id);
-      console.log("Grading summary:", summary);
 
       return ctx.prisma.quizAttempt.findUniqueOrThrow({
         ...query,


### PR DESCRIPTION
<!--
  Welcome to Synth Tree!
  Please fill out this template completely to help reviewers understand your changes.
  Sections marked with ⚠️ are REQUIRED.
-->

## ⚠️ Jira Task

<!--
  Link to the Jira task this PR addresses.
  Format: ST-XXX
  Example: ST-123
-->

**Jira Task ID:** ST-74
**Jira Link:** [ST-74](https://tripleten-apiary.atlassian.net/browse/ST-74?atlOrigin=eyJpIjoiN2FkMjU2NGE0OTJmNDdlOGE1YTJhMDMwNDdmMTgyMTUiLCJwIjoiaiJ9)

---

## ⚠️ Description

This adds a new submitQuizAttempt mutation that utilizes the auto grader so that users can submit quizzes and get their results back.

### What changes were made?

A completely new mutation was made.

### Why were these changes necessary?

These changes are necessary because taking a quiz and getting results back are important to the user experience so they can focus on what they need to improve on. There's also no point in making quizzes if you aren't able to submit them.

---

## ⚠️ Type of Change

<!-- Mark the type(s) of change with an [x] -->

- [x] 🎨 New Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] ♻️ Code Refactor
- [ ] ⚡ Performance Improvement
- [ ] ✅ Test Addition/Update
- [ ] 🔧 Configuration Change
- [ ] 🗑️ Code Removal

---

## ⚠️ Changes Made

<!--
  List the specific changes made in this PR
  Be detailed and specific - help reviewers understand exactly what changed
-->

Change 1: The only change made was the addition of the submitQuizAttempt mutation. This mutation does not only send back your results, but also saves your attempt to the database. For each answer, a QuizAttemptAnswer is also stored in the database.

---

## ⚠️ Testing

<!--
  Describe how you tested these changes
  Include specific test cases, scenarios, or steps to reproduce
-->

Testing is once again similar to the other quiz mutations I've made in the past where it is all done within the Apollo Sandbox. After creating our quiz questions and quiz options we can start to test this new mutation with any account, admin or not. 

### Testing Steps

Step 1. Go through all of the steps to create a Quiz, QuizQuestion, and QuizOption. You can find a more detailed explanation here: https://github.com/tripleten-externships/synth-tree/pull/41.

Step 2. Start setting up a submitQuizAttempt mutation. The formatting for this is kind of complicated, so here's an example: 
{
  "quizId": "895a96c4-02d1-4ab6-855b-6ac4304325cb",
  "answers": [
    "{\"questionId\": \"7b2386bf-9d99-4cf3-ac97-09a03ae907fb\", \"answer\": {\"selectedOptionIds\": [\"c7bc259b-9714-4934-8658-12fae71f1f3b\", \"34e73b3d-2dd6-4e6b-8909-95deae424bcf\"]}}",
    "{\"questionId\": \"5afbec51-a2dd-4c3b-9983-9bfd730ba8aa\", \"answer\": {\"selectedOptionIds\": [\"dd9ce842-f410-4eb4-9b5c-20eaa5ed40ab\"]}}",
    "{\"questionId\": \"2044ba71-0f6f-4ea4-bd50-3f7623553b5e\", \"answer\": {\"text\": \"Answer\"}}"
  ]
}

The IDs here are just an example and you'll have to provide your own IDs from Step 1.
Basically we start off with the quizID in it's own argument, and then we have the "answers" argument that is an array of questions + answers. For the example: the first question is a MULTIPLE_CHOICE, the second answer is a SINGLE_CHOICE, and the third answer is an OPEN_QUESTION.
(in the MULTIPLE_CHOICE it actually contains two answers in the example)

Step 3: Once you get it all setup you can test multiple scenarios by submitting wrong/right answers, leaving out questions that are in the quiz, and using different accounts. A lot of these scenarios are going to be handled by the already existing auto grader.

### Test Results

When I tested I found that I would pass/fail depending on the amount of questions I got wrong. I also realized that I would always fail if I omitted a question that was in a quiz. You would also fail if you mix and match questions/options with other quizzes. Formatting is also very important here because it will give you an error message if it is formatted wrong, which is why I wanted to give a full example.

### Browser/Environment Tested

Chrome 144
Node 22.20.0

---

## Screenshots/Videos (if applicable)

<!--
  If your changes affect the UI, add screenshots or videos here
  Before/After comparisons are especially helpful!
  You can drag and drop images directly into this text box
-->

### Before

### After

---

## ⚠️ Pre-Submission Checklist

<!--
  Review this checklist before submitting your PR
  ALL items must be checked before your PR can be merged
-->

- [x] ✅ My code follows the project's style conventions and guidelines
- [x] ✅ I have performed a self-review of my own code
- [x] ✅ I have commented my code, particularly in hard-to-understand areas
- [x] ✅ My branch is up to date with `main`
- [x] ✅ I have used descriptive commit messages
- [x] ✅ I have tested my changes thoroughly
- [x] ✅ All existing tests pass with my changes
- [x] ✅ I have added tests that prove my fix is effective or that my feature works
- [x] ✅ I have updated documentation (if needed)
- [x] ✅ My changes generate no new warnings or errors
- [x] ✅ My branch name follows the convention: `feature/ST-XXX-description` or `bugfix/ST-XXX-description`

---

## Additional Notes

<!--
  Any additional information that reviewers should know
  - Known issues or limitations
  - Future improvements planned
  - Dependencies on other PRs
  - Migration steps required
-->
I think this can be improved if we switched to using an InputType instead of a stringList for answers. Right now we have to parse the answers so it is readable for the auto grader, but we can skip this step if we switch to InputTypes. I didn't want to implement it this time around because the ticket doesn't mention it and it may be out of scope.

---

## Review Checklist (For Reviewers)

- [ ] Code quality and style are consistent
- [ ] Changes align with the Jira task requirements
- [ ] Tests are sufficient and passing
- [ ] Documentation is updated
- [ ] No security vulnerabilities introduced
- [ ] Performance impact is acceptable
