### PR TITLE
feat(ST-58): implement courses management page

### DIFF
--- a/apps/admin-dashboard/package.json
+++ b/apps/admin-dashboard/package.json
@@ -19,6 +19,7 @@
     "@skilltree/ui": "workspace:*",
     "firebase": "^11.1.0",
     "graphql": "^16.11.0",
+    "lucide-react": "^0.344.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-hook-form": "^7.63.0",

--- a/apps/admin-dashboard/src/App.tsx
+++ b/apps/admin-dashboard/src/App.tsx
@@ -6,6 +6,7 @@ import DashboardLayout from "./layouts/DashboardLayout";
 
 import ErrorBoundary from "./components/ErrorBoundary";
 import { ColorPickerDemoPage } from "./pages/ColorPickerDemoPage";
+import CoursesList from "./pages/courses/CoursesList";
 import { ToastProvider } from "./components/Toast";
 
 function App() {
@@ -16,35 +17,26 @@ function App() {
           <ToastProvider>
             <Routes>
               <Route path="/auth/*" element={<AuthFeature />} />
-              <Route
+<Route
                 path="/*"
                 element={
                   <ProtectedRoutes>
                     <Routes>
                       <Route
                         path="/dashboard"
-                        element={
-                          <DashboardLayout>
-                            <div className="flex flex-col ml-16 items-start mt-16">
-                              <h1 className="text-3xl font-bold mb-2">
-                                Courses
-                              </h1>
-                              <p className="text-lg text-muted-foreground mb-8">
-                                No courses yet
-                              </p>
-                              <div className="flex flex-col items-center justify-center border border-gray-200 rounded-lg w-72 h-40">
-                                <span className="text-3xl mb-2">+</span>
-                                <span className="text-base font-bold">
-                                  New Course
-                                </span>
-                              </div>
-                            </div>
-                          </DashboardLayout>
-                        }
+                        element={<Navigate to="/courses" replace />}
                       />
                       <Route
                         path="/"
-                        element={<Navigate to="/dashboard" replace />}
+                        element={<Navigate to="/courses" replace />}
+                      />
+                      <Route
+                        path="/courses"
+                        element={
+                          <DashboardLayout>
+                            <CoursesList />
+                          </DashboardLayout>
+                        }
                       />
                       <Route
                         path="/color-picker-demo"

--- a/apps/admin-dashboard/src/layouts/DashboardLayout.tsx
+++ b/apps/admin-dashboard/src/layouts/DashboardLayout.tsx
@@ -28,7 +28,7 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
           <img
             src={SkillTreeLogo}
             alt="SkillTree logo"
-            className="h-6 w-auto"
+            className="h-6 w-auto dark:brightness-0 dark:invert"
           />
         </div>
         {/* RIGHT: Courses link, avatar + admin badge container*/}
@@ -48,7 +48,7 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
                   <img
                     src={user?.photoURL || GenericAvatar}
                     alt={user?.displayName || "User"}
-                    className="h-8 w-8 rounded-full"
+                    className="h-8 w-8 rounded-full dark:brightness-0 dark:invert"
                   />
                 </button>
               </DropdownMenuTrigger>

--- a/apps/admin-dashboard/src/pages/courses/CoursesList.tsx
+++ b/apps/admin-dashboard/src/pages/courses/CoursesList.tsx
@@ -1,0 +1,398 @@
+import { gql } from "@apollo/client";
+import { useQuery, useMutation } from "@apollo/client/react";
+import { useState } from "react";
+import {
+  MoreHorizontal,
+  Plus,
+  Eye,
+  TrendingDown,
+  FlaskConical,
+  type LucideIcon,
+} from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  Input,
+} from "@skilltree/ui";
+
+// ─── 1. GRAPHQL ───────────────────────────────────────────────────────────────
+
+const GET_ALL_COURSES = gql`
+  query AdminGetAllCourses($status: CourseStatus) {
+    adminGetAllCourses(status: $status) {
+      id
+      title
+      description
+      status
+      author {
+        id
+        name
+        email
+      }
+    }
+  }
+`;
+
+const DELETE_COURSE = gql`
+  mutation DeleteCourse($id: ID!) {
+    deleteCourse(id: $id) {
+      id
+    }
+  }
+`;
+
+const UPDATE_COURSE = gql`
+  mutation UpdateCourse($id: ID!, $input: UpdateCourseInput!) {
+    updateCourse(id: $id, input: $input) {
+      id
+      status
+    }
+  }
+`;
+
+const CREATE_COURSE = gql`
+  mutation CreateCourse($input: CreateCourseInput!) {
+    createCourse(input: $input) {
+      id
+      title
+    }
+  }
+`;
+
+// ─── 2. TYPES ─────────────────────────────────────────────────────────────────
+
+type CourseStatus = "DRAFT" | "PUBLISHED";
+type StatusFilter = "ALL" | CourseStatus;
+
+type Course = {
+  id: string;
+  title: string;
+  description?: string | null;
+  status: CourseStatus;
+  author: {
+    id: string;
+    name?: string | null;
+    email: string;
+  };
+};
+
+// ─── 3. SUB-COMPONENTS ────────────────────────────────────────────────────────
+
+const StatusBadge = ({ status }: { status: CourseStatus }) => {
+  const isPublished = status === "PUBLISHED";
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-1 rounded-full ${
+        isPublished
+          ? "bg-green-100 text-green-700"
+          : "bg-gray-100 text-gray-600"
+      }`}
+    >
+      {isPublished ? (
+        <Eye className="w-3 h-3" />
+      ) : (
+        <TrendingDown className="w-3 h-3" />
+      )}
+      {isPublished ? "Published" : "Draft"}
+    </span>
+  );
+};
+
+const HexIcon = ({ Icon = FlaskConical }: { Icon?: LucideIcon }) => (
+  <div
+    className="w-16 h-16 bg-blue-500 flex items-center justify-center mb-4"
+    style={{
+      clipPath: "polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)",
+    }}
+  >
+    <Icon className="w-8 h-8 text-white" />
+  </div>
+);
+
+const SkeletonCard = () => (
+  <div className="border border-gray-200 rounded-xl p-6 animate-pulse">
+    <div className="w-16 h-16 bg-gray-200 rounded-lg mb-4" />
+    <div className="h-5 bg-gray-200 rounded w-3/4 mb-2" />
+    <div className="h-4 bg-gray-200 rounded w-full mb-1" />
+    <div className="h-4 bg-gray-200 rounded w-1/3 mt-3" />
+  </div>
+);
+
+const NewCourseCard = ({ onClick }: { onClick: () => void }) => (
+  <button
+    onClick={onClick}
+    className="border border-gray-200 rounded-xl p-6 flex flex-col items-center justify-center hover:shadow-md transition-shadow min-h-[180px] w-full"
+  >
+    <Plus className="w-6 h-6 mb-2 text-gray-500" />
+    <span className="text-base font-medium text-gray-700">New course</span>
+  </button>
+);
+
+// ─── 4. COURSE CARD ───────────────────────────────────────────────────────────
+
+type CourseCardProps = {
+  course: Course;
+  onDelete: (id: string) => void;
+  onPublish: (id: string) => void;
+  Icon?: LucideIcon;
+};
+
+const CourseCard = ({ course, onDelete, onPublish, Icon }: CourseCardProps) => (
+  <div className="border border-gray-200 rounded-xl p-6 relative hover:shadow-md transition-shadow">
+    <div className="absolute top-4 right-4">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button className="p-1 rounded hover:bg-gray-100">
+            <MoreHorizontal className="w-5 h-5 text-gray-500" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={() => alert("TODO: open edit modal")}>
+            Edit course
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => onPublish(course.id)}>
+            {course.status === "PUBLISHED" ? "Unpublish course" : "Publish course"}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            variant="destructive"
+            onClick={() => onDelete(course.id)}
+          >
+            Delete course
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+
+    <HexIcon Icon={Icon} />
+    <h3 className="font-semibold text-lg mb-1">{course.title}</h3>
+    {course.description && (
+      <p className="text-sm text-gray-500 mb-3 line-clamp-2">
+        {course.description}
+      </p>
+    )}
+    <p className="text-xs text-gray-400 mb-3">
+      by {course.author.name ?? course.author.email}
+    </p>
+    <StatusBadge status={course.status} />
+  </div>
+);
+
+// ─── 5. CREATE COURSE MODAL ───────────────────────────────────────────────────
+
+type CreateCourseModalProps = {
+  open: boolean;
+  onClose: () => void;
+  onCreated: () => void;
+};
+
+const CreateCourseModal = ({ open, onClose, onCreated }: CreateCourseModalProps) => {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+
+  const [createCourse, { loading }] = useMutation(CREATE_COURSE, {
+    refetchQueries: [{ query: GET_ALL_COURSES }],
+    onCompleted: () => {
+      setTitle("");
+      setDescription("");
+      onCreated();
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+    createCourse({ variables: { input: { title, description } } });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create Course</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4 mt-2">
+          <div>
+            <label className="text-sm font-medium block mb-1">
+              Title <span className="text-red-500">*</span>
+            </label>
+            <Input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="e.g. Organic Chemistry"
+              required
+            />
+          </div>
+          <div>
+            <label className="text-sm font-medium block mb-1">
+              Description
+            </label>
+            <Input
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Short description of the course"
+            />
+          </div>
+          <DialogFooter>
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm rounded-lg border border-gray-300 hover:bg-gray-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={loading || !title.trim()}
+              className="px-4 py-2 text-sm rounded-lg bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-50"
+            >
+              {loading ? "Creating..." : "Create Course"}
+            </button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+// ─── 6. MAIN PAGE ─────────────────────────────────────────────────────────────
+
+const CoursesList = () => {
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("ALL");
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const { data, loading, error } = useQuery<{ adminGetAllCourses: Course[] }>(
+    GET_ALL_COURSES,
+    {
+      variables: statusFilter !== "ALL" ? { status: statusFilter } : {},
+    }
+  );
+
+  const [deleteCourse] = useMutation(DELETE_COURSE, {
+    refetchQueries: [{ query: GET_ALL_COURSES }],
+  });
+
+  const [updateCourse] = useMutation(UPDATE_COURSE, {
+    refetchQueries: [{ query: GET_ALL_COURSES }],
+  });
+
+  const handleDelete = (id: string) => {
+    if (window.confirm("Are you sure you want to delete this course?")) {
+      deleteCourse({ variables: { id } });
+    }
+  };
+
+  const handlePublish = (id: string) => {
+    const course = courses.find((c) => c.id === id);
+    if (!course) return;
+    const newStatus = course.status === "PUBLISHED" ? "DRAFT" : "PUBLISHED";
+    updateCourse({ variables: { id, input: { status: newStatus } } });
+  };
+
+  const courses: Course[] = data?.adminGetAllCourses ?? [];
+  const isEmpty = !loading && !error && courses.length === 0;
+
+  const filterOptions: { label: string; value: StatusFilter }[] = [
+    { label: "All", value: "ALL" },
+    { label: "Published", value: "PUBLISHED" },
+    { label: "Draft", value: "DRAFT" },
+  ];
+
+  return (
+    <div className="flex flex-col ml-16 mt-16">
+
+      {/* ── Header ── */}
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-3xl font-bold">Courses</h1>
+        <button
+          onClick={() => setModalOpen(true)}
+          className="flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium px-4 py-2 rounded-lg"
+        >
+          <Plus className="w-4 h-4" />
+          Create Course
+        </button>
+      </div>
+
+      {/* ── Filter pills ── */}
+      <div className="flex gap-2 mb-6">
+        {filterOptions.map((opt) => (
+          <button
+            key={opt.value}
+            onClick={() => setStatusFilter(opt.value)}
+            className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors ${
+              statusFilter === opt.value
+                ? "bg-blue-600 text-white"
+                : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+            }`}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+
+      {/* ── Error state ── */}
+      {error && (
+        <div className="text-red-600 bg-red-50 border border-red-200 rounded-lg p-4 mb-6">
+          Failed to load courses. Please try again.
+        </div>
+      )}
+
+      {/* ── Loading skeletons ── */}
+      {loading && (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {[1, 2, 3].map((n) => (
+            <SkeletonCard key={n} />
+          ))}
+        </div>
+      )}
+
+      {/* ── Empty state ── */}
+      {isEmpty && (
+        <div className="flex flex-col items-center justify-center py-24 text-center">
+          <p className="text-gray-500 text-lg mb-2">No courses yet</p>
+          <p className="text-gray-400 text-sm mb-6">
+            Get started by creating your first course.
+          </p>
+          <button
+            onClick={() => setModalOpen(true)}
+            className="flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium px-4 py-2 rounded-lg"
+          >
+            <Plus className="w-4 h-4" />
+            Create First Course
+          </button>
+        </div>
+      )}
+
+      {/* ── Grid ── */}
+      {!loading && !error && courses.length > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {courses.map((course) => (
+            <CourseCard
+              key={course.id}
+              course={course}
+              onDelete={handleDelete}
+              onPublish={handlePublish}
+            />
+          ))}
+          <NewCourseCard onClick={() => setModalOpen(true)} />
+        </div>
+      )}
+
+      {/* ── Create Course Modal ── */}
+      <CreateCourseModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onCreated={() => setModalOpen(false)}
+      />
+    </div>
+  );
+};
+
+export default CoursesList;

--- a/apps/admin-dashboard/vite.config.ts
+++ b/apps/admin-dashboard/vite.config.ts
@@ -4,4 +4,8 @@ import { defineConfig } from "vite";
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    port: 5173,
+    strictPort: false,
+  },
 });

--- a/apps/api/src/graphql/queries/index.ts
+++ b/apps/api/src/graphql/queries/index.ts
@@ -1,13 +1,14 @@
 import "./lessonBlock";
 import "./skillNode";
 import "./user";
-import "./course.admin.queries";
-import "./course.owner.queries";
 import "./skillTree.admin.queries";
 import "./skillTree.owner.queries";
 import "./skillNode.admin.queries";
 import "./skillNode.owner.queries";
 import "./progress.queries";
 import "./quiz.queries";
+
+import "./course.admin.queries";
+import "./course.owner.queries";
 
 // import queries/*.ts files here

--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -21,14 +21,12 @@ const config: StorybookConfig = {
     },
   },
   viteFinal: async (config) => {
-    // Ensure CSS is processed correctly
     if (config.css) {
       config.css.postcss = {
         plugins: [require("tailwindcss"), require("autoprefixer")],
       };
     }
 
-    // Add alias resolution for @/* paths and workspace packages
     config.resolve = config.resolve || {};
     config.resolve.alias = {
       ...config.resolve.alias,

--- a/packages/ui/.storybook/package.json
+++ b/packages/ui/.storybook/package.json
@@ -1,0 +1,1 @@
+{ "type": "commonjs" }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ importers:
       graphql:
         specifier: ^16.11.0
         version: 16.11.0
+      lucide-react:
+        specifier: ^0.344.0
+        version: 0.344.0(react@19.1.1)
       react:
         specifier: ^19.1.1
         version: 19.1.1
@@ -5266,11 +5269,12 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -7255,7 +7259,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   teeny-request@9.0.0:
     resolution: {integrity: sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==}


### PR DESCRIPTION
Jira Task ID: ST-58
Jira Link: [ST-58](https://tripleten-externships.atlassian.net/browse/ST-58)

⚠️ Description
What changes were made?
Implemented the full Courses Management page for the admin dashboard. Admins can now view, create, publish/unpublish, delete, and filter courses from a single page.

Why were these changes necessary?
Admins had no way to manage courses from the dashboard. This page provides the central UI for course management as specified in ST-58.

⚠️ Type of Change
 🎨 New Feature
 🔧 Configuration Change
⚠️ Changes Made
Created CoursesList page at apps/admin-dashboard/src/pages/courses/CoursesList.tsx
Course cards display hexagonal icon, title, description, author, color-coded status badge, and kebab menu
Create Course button (top-right) opens modal wired to createCourse mutation
Publish/Unpublish action in kebab menu wired to updateCourse mutation
Delete action in kebab menu wired to deleteCourse mutation
Color-coded status badges — green pill for Published, gray for Draft
Empty state with helpful message and Create First Course CTA button
Filter by status — All / Published / Draft pills connected to adminGetAllCourses $status variable
Loading skeleton cards during fetch
Error state handled gracefully
Registered course.admin.queries and course.owner.queries in queries/index.ts
Added /courses route to App.tsx with redirect from /dashboard
Fixed Storybook CommonJS/ESM conflict with .storybook/package.json scope override
Dark mode visibility fixes for SkillTree logo and avatar in DashboardLayout
⚠️ Testing
Testing Steps
Log in at /auth/login with shared dev credentials
Navigate to /courses
Verify empty state shows with "Create First Course" button
Click Create Course — fill in title and description — click Create
Verify the new course card appears in the grid with Draft badge
Click the kebab menu (⋯) — click Publish course — verify badge turns green
Click Published filter pill — verify only published courses show
Click Draft filter pill — verify only draft courses show
Click kebab menu → Delete course — confirm dialog — verify card is removed
Resize browser window to verify responsive grid (1/2/3 columns)
Test Results
All steps above tested and working locally.

Browser/Environment Tested
Chrome, Node 24.x, Windows 11

Screenshots/Videos
See designs: docs/Skill Tree Platform/Courses Admin.png and docs/Skill Tree Platform/Courses Admin-1.png

⚠️ Pre-Submission Checklist
 ✅ My code follows the project's style conventions and guidelines
 ✅ I have performed a self-review of my own code
 ✅ My branch is up to date with main
 ✅ I have used descriptive commit messages
 ✅ I have tested my changes thoroughly
 ✅ My changes generate no new warnings or errors
 ✅ My branch name follows the convention: feature/ST-58-build-courses-list-page