### PR TITLE
feat(client-frontend): start node progress on lesson open (SYN-31)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "scripts": {
+    "prisma": "prisma",
     "dev": "nodemon --exec ts-node -r tsconfig-paths/register src/index.ts",
     "build": "pnpm generate && tsc -p tsconfig.json",
     "generate": "prisma generate",

--- a/apps/api/src/graphql/mutations/index.ts
+++ b/apps/api/src/graphql/mutations/index.ts
@@ -2,6 +2,7 @@
 // shared Pothos builder. Keep this list alphabetized by domain.
 import "./course.mutations";
 import "./lessonBlock.mutations";
+import "./progress.mutations";
 import "./quiz.mutations";
 import "./skillNode.delete.advanced.mutations";
 import "./skillNode.delete.simple.mutations";

--- a/apps/api/src/graphql/mutations/progress.mutations.ts
+++ b/apps/api/src/graphql/mutations/progress.mutations.ts
@@ -1,0 +1,53 @@
+import { GraphQLError } from "graphql";
+import { builder } from "@graphql/builder";
+
+builder.mutationFields((t) => ({
+  startNodeProgress: t.prismaField({
+    type: "UserNodeProgress",
+    args: {
+      nodeId: t.arg.id({ required: true }),
+    },
+
+    resolve: async (query, _root, { nodeId }, ctx) => {
+      const userId = ctx.auth.requireAuth();
+
+      // validate node exists and is not deleted
+      const nodeExists = await ctx.prisma.skillNode.findFirst({
+        where: {
+          id: nodeId,
+          deletedAt: null,
+        },
+        select: { id: true },
+      });
+
+      if (!nodeExists) {
+        throw new GraphQLError("Node not found");
+      }
+
+      // idempotent behavior
+      const existingProgress =
+        await ctx.prisma.userNodeProgress.findUnique({
+          ...query,
+          where: {
+            userId_nodeId: {
+              userId,
+              nodeId,
+            },
+          },
+        });
+
+      if (existingProgress) {
+        return existingProgress;
+      }
+
+      return ctx.prisma.userNodeProgress.create({
+        ...query,
+        data: {
+          userId,
+          nodeId,
+          status: "IN_PROGRESS",
+        },
+      });
+    },
+  }),
+}));

--- a/apps/client-frontend/src/components/LessonViewer.tsx
+++ b/apps/client-frontend/src/components/LessonViewer.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import DOMPurify from "dompurify";
 import ReactPlayer from "react-player";
-import { useQuery } from "@apollo/client/react";
+import { useQuery, useMutation } from "@apollo/client/react";
 import { ContentType } from "@synth-tree/api-types";
 import { LESSON_BLOCKS_QUERY } from "../graphql/queries/lessonBlocks";
+import { START_NODE_PROGRESS } from "../graphql/mutations/startNodeProgress";
 
 interface LessonBlock {
   id: string;

--- a/apps/client-frontend/src/components/LessonViewer.tsx
+++ b/apps/client-frontend/src/components/LessonViewer.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import DOMPurify from "dompurify";
 import ReactPlayer from "react-player";
 import { useQuery, useMutation } from "@apollo/client/react";
@@ -27,6 +27,16 @@ export const LessonViewer: React.FC<LessonViewerProps> = ({ nodeId, onNext }) =>
   const { data, loading, error } = useQuery<LessonBlocksData>(LESSON_BLOCKS_QUERY, {
     variables: { nodeId },
   });
+
+  const [startNodeProgress] = useMutation(START_NODE_PROGRESS);
+
+  // Mark this node as in-progress when the learner opens the lesson.
+  // The mutation is idempotent server-side, so revisits / re-renders are safe.
+  useEffect(() => {
+    startNodeProgress({ variables: { nodeId } }).catch(() => {
+      // Best-effort progress tracking — don't block the lesson on failure.
+    });
+  }, [nodeId, startNodeProgress]);
 
   if (loading) return <div>Loading lesson...</div>;
   if (error) return <div>Error loading lesson.</div>;

--- a/apps/client-frontend/src/graphql/mutations/startNodeProgress.ts
+++ b/apps/client-frontend/src/graphql/mutations/startNodeProgress.ts
@@ -1,0 +1,10 @@
+import { gql } from "@apollo/client";
+
+export const START_NODE_PROGRESS = gql`
+  mutation StartNodeProgress($nodeId: ID!) {
+    startNodeProgress(nodeId: $nodeId) {
+      id
+      status
+    }
+  }
+`;


### PR DESCRIPTION
## ⚠️ Jira Task

**Jira Task ID:** SYN-31
**Jira Link:** [[SYN-31](https://your-jira-instance.atlassian.net/browse/SYN-31)](https://your-jira-instance.atlassian.net/browse/SYN-31)

---

## ⚠️ Description

### What changes were made?

Added support for automatically starting node progress when a learner opens a lesson for the first time.

Implemented a new `startNodeProgress` GraphQL mutation that creates a `UserNodeProgress` record with status `IN_PROGRESS` when one does not already exist. Added the frontend mutation definition and wired the lesson viewer to trigger the mutation when a lesson is opened.

### Why were these changes necessary?

This change satisfies the SYN-31 requirements by ensuring learner progress is tracked as soon as a lesson is opened. The progress state is later used by the skill tree to determine node status and progression.

---

## ⚠️ Type of Change

* [x] 🎨 New Feature
* [ ] 🐛 Bug Fix
* [ ] 📝 Documentation Update
* [ ] ♻️ Code Refactor
* [ ] ⚡ Performance Improvement
* [ ] ✅ Test Addition/Update
* [ ] 🔧 Configuration Change
* [ ] 🗑️ Code Removal

---

## ⚠️ Changes Made

* Added `startNodeProgress` GraphQL mutation in the API
* Implemented idempotent progress creation logic to prevent duplicate records
* Added frontend GraphQL mutation definition for `startNodeProgress`
* Wired the lesson viewer to trigger the mutation when a lesson is opened
* Exported the mutation through the GraphQL mutations index

---

## ⚠️ Testing

### Testing Steps

1. Created a test Course, SkillTree, and SkillNode through GraphQL mutations
2. Executed `startNodeProgress` for the test node
3. Verified a `UserNodeProgress` row was created with status `IN_PROGRESS`
4. Executed the mutation a second time for the same user and node
5. Verified that no duplicate progress row was created
6. Confirmed the existing record was returned unchanged

### Test Results

The mutation successfully creates a progress record on first execution and returns the existing record on subsequent executions. No duplicate rows were created. The resulting status remained `IN_PROGRESS` as expected.

### Browser/Environment Tested

* Apollo Sandbox
* Prisma Studio
* Local development environment

---

## Screenshots/Videos (if applicable)

### Before

No `UserNodeProgress` record existed for a learner opening a lesson for the first time.

### After

Opening a lesson creates a `UserNodeProgress` record with status `IN_PROGRESS`, and subsequent opens reuse the existing record.

---

## ⚠️ Pre-Submission Checklist

* [x] ✅ My code follows the project's style conventions and guidelines
* [x] ✅ I have performed a self-review of my own code
* [x] ✅ I have commented my code, particularly in hard-to-understand areas
* [ ] ✅ My branch is up to date with `main`
* [x] ✅ I have used descriptive commit messages
* [x] ✅ I have tested my changes thoroughly
* [ ] ✅ All existing tests pass with my changes
* [ ] ✅ I have added tests that prove my fix is effective or that my feature works
* [ ] ✅ I have updated documentation (if needed)
* [x] ✅ My changes generate no new warnings or errors
* [x] ✅ My branch name follows the convention: `feature/SYN-XXX-description` or `bugfix/SYN-XXX-description`

---

## Additional Notes

The mutation was implemented with idempotent behavior to satisfy the acceptance criteria that reopening a lesson should not create duplicate progress records.

Testing was performed using Apollo Sandbox and Prisma Studio to verify both record creation and duplicate prevention behavior.

---

## Review Checklist (For Reviewers)

* [ ] Code quality and style are consistent
* [ ] Changes align with the Jira task requirements
* [ ] Tests are sufficient and passing
* [ ] Documentation is updated
* [ ] No security vulnerabilities introduced
* [ ] Performance impact is acceptable