### PR TITLE
fix(api): pass open-only quiz attempts automatically (SYN-54)

### DIFF
--- a/apps/api/src/services/quiz/__tests__/gradeQuizAttempt.test.ts
+++ b/apps/api/src/services/quiz/__tests__/gradeQuizAttempt.test.ts
@@ -83,8 +83,8 @@ describe("gradeQuizAttempt", () => {
     expect(result.passed).toBe(true);
     expect(result.message).toBe("Passed");
   });
-  // OPEN_QUESTION triggers manual review
-  it("handles OPEN_QUESTION as manual review", async () => {
+  // OPEN_QUESTION-only quiz passes outright (SYN-54: nothing to grade against)
+  it("passes an open-only quiz with a single OPEN_QUESTION", async () => {
     const mockQuiz = {
       questions: [
         {
@@ -108,10 +108,8 @@ describe("gradeQuizAttempt", () => {
 
     const result = await gradeQuizAttempt(mockTx as any, "attempt3");
     expect(result.correctCount).toBe(0);
-    expect(result.passed).toBe(null); // Expect null for manual review
-    expect(result.message).toBe(
-      "Passed pending manual review of open question(s)",
-    );
+    expect(result.passed).toBe(true); // SYN-54: open-only quiz passes
+    expect(result.message).toBe("Passed");
   });
   // MULTIPLE_CHOICE partially correct (includes incorrect option)
   it("fails when MULTIPLE_CHOICE answer is partially correct", async () => {
@@ -173,10 +171,8 @@ describe("gradeQuizAttempt", () => {
 
     const result = await gradeQuizAttempt(mockTx as any, "attempt6");
     expect(result.correctCount).toBe(0);
-    expect(result.passed).toBe(null);
-    expect(result.message).toBe(
-      "Passed pending manual review of open question(s)",
-    );
+    expect(result.passed).toBe(true); // SYN-54: open-only quiz passes
+    expect(result.message).toBe("Passed");
   });
   // Quiz with all three types of questions - all auto-gradable correct
   it("handles a quiz with SINGLE_CHOICE, MULTIPLE_CHOICE, and OPEN_QUESTION", async () => {

--- a/apps/api/src/services/quiz/gradeQuizAttempt.ts
+++ b/apps/api/src/services/quiz/gradeQuizAttempt.ts
@@ -145,10 +145,17 @@ export async function gradeQuizAttempt(
   let message: string;
 
   // Decide pass status and message
-  // - If any open-ended questions are present and not yet graded, mark as pending manual review (passed = null).
-  // - If there are no auto-gradable questions (only open questions), mark as pending manual review (passed = null)
-  // - Otherwise, pass only if all auto-gradable questions are answered and correct.
-  if (hasUngradedOpen || totalAutoGradableQuestions === 0) {
+  // - SYN-54: If the quiz has ONLY open questions (nothing to auto-grade
+  //   against), the attempt passes outright.
+  // - If there is a mix of auto-gradable and ungraded open questions, mark as
+  //   pending manual review (passed = null) when the auto-gradable answers are
+  //   all correct, otherwise not passed.
+  // - Otherwise (no open questions), pass only if all auto-gradable questions
+  //   are answered and correct.
+  if (totalAutoGradableQuestions === 0) {
+    passed = true;
+    message = "Passed";
+  } else if (hasUngradedOpen) {
     if (allAnswered && allAutoGradableCorrect) {
       passed = null;
       message = "Passed pending manual review of open question(s)";


### PR DESCRIPTION
## ⚠️ Jira Task

**Jira Task ID:** SYN-54
**Jira Link:** [SYN-54](https://tripleten-apiary.atlassian.net/browse/SYN-54)

---

## ⚠️ Description

### What changes were made?

This PR covers the backend part of SYN-54 for open-ended (`OPEN_QUESTION`) quizzes.

When a quiz is made up of only open-ended questions, there is nothing for the
auto-grader to check the answer against, so the attempt should just pass. Before
this change, the grader treated an open-only quiz the same as a mixed quiz and
left it as "pending manual review", which stopped the learner from passing.

I updated `gradeQuizAttempt` to handle the open-only case on its own and return
`passed: true`. Mixed quizzes (auto-gradable questions plus open ones) are not
changed and still come back as pending manual review when the auto-graded answers
are correct.

I also checked the other acceptance criterion (open answers persisting as
`{ text: "..." }`). That already works: `submitQuizAttempt` stores each answer's
JSON as-is, and the grader only sets `isCorrect = null` for open questions without
touching the saved text.

### Why were these changes necessary?

SYN-54 says submitting an open-only quiz should pass the user, since there is
nothing to grade against. This makes the grading logic match that requirement.

---

## ⚠️ Type of Change

- [x] 🐛 Bug Fix
- [x] ✅ Test Addition/Update

---

## ⚠️ Changes Made

- `apps/api/src/services/quiz/gradeQuizAttempt.ts` — open-only quizzes now return `passed: true` ("Passed") instead of `passed: null`.
- `apps/api/src/services/quiz/__tests__/gradeQuizAttempt.test.ts` — updated the single-open-question and all-open-questions tests to expect `passed: true` / "Passed".

---

## ⚠️ Testing

### Testing Steps

1. `cd apps/api`
2. `pnpm test gradeQuizAttempt`

### Test Results

All 11 grading tests pass, including the two open-only cases now expecting
`passed: true`. The mixed-quiz tests still expect `passed: null`, so nothing else
changed.

### Browser/Environment Tested

Node (jest unit tests). No UI in this change.

---

## Additional Notes

The ticket description also mentions rendering `OPEN_QUESTION` as a textarea and
showing the rubric in a callout after submission. This PR is intentionally kept
backend-only, and those parts are split into separate tickets:

- The rubric field on `QuizQuestion` will be added in a separate ticket (not in
  this PR).
- The textarea and rubric callout UI will be done under a future learner quiz UI
  ticket, once that screen exists. Right now there is no quiz-taking component in
  `apps/client-frontend` to add them to.

So this PR closes the backend scope of SYN-54 only.

---

## ⚠️ Pre-Submission Checklist

- [x] ✅ My code follows the project's style conventions and guidelines
- [x] ✅ I have performed a self-review of my own code
- [x] ✅ I have commented my code, particularly in hard-to-understand areas
- [x] ✅ My branch is up to date with `main`
- [x] ✅ I have used descriptive commit messages
- [x] ✅ All existing tests pass with my changes
- [x] ✅ I have added/updated tests that prove my fix works
- [x] ✅ My branch name follows the convention: `feature/SYN-54-open-question-ui`
