### PR TITLE
SYN-60: Multi-page lessons with page breaks

### DIFF
--- a/apps/api/prisma/migrations/20260618212928_add_page_break_content_type/migration.sql
+++ b/apps/api/prisma/migrations/20260618212928_add_page_break_content_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "ContentType" ADD VALUE 'PAGE_BREAK';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -17,10 +17,10 @@ generator pothosCrud {
   // The environment variable will override the path hardcoded here.
 }
 
-// Refer to branch: ST-13-design-minimal-viable-database-schema for more in-depth information  
-// The ST-13 branch database-schema.md document also has a show case for using the prisma orm and these models. 
-//Rewards and Gamification intentionally not implemented yet.  
-// Leaving comments in the schema file. Request removal if the team does not want this. 
+// Refer to branch: ST-13-design-minimal-viable-database-schema for more in-depth information
+// The ST-13 branch database-schema.md document also has a show case for using the prisma orm and these models.
+//Rewards and Gamification intentionally not implemented yet.
+// Leaving comments in the schema file. Request removal if the team does not want this.
 
 datasource db {
   provider = "postgresql"
@@ -43,6 +43,7 @@ enum ContentType {
   VIDEO
   EMBED
   HTML
+  PAGE_BREAK
 }
 
 enum LessonStatus {
@@ -207,8 +208,8 @@ model LessonBlocks {
 // Quiz
 // - At most one quiz per node (nodeId is unique).
 // - `required` means the quiz must be taken for completion logic,
-//   but grading uses only booleans in v1 (no numeric scores). 
-// Rewards can be used later on and completed lessons result in points or unit of choice. 
+//   but grading uses only booleans in v1 (no numeric scores).
+// Rewards can be used later on and completed lessons result in points or unit of choice.
 // ================================================================
 model Quiz {
   id        String    @id @default(uuid()) @db.Uuid

--- a/apps/api/src/graphql/schema.graphql
+++ b/apps/api/src/graphql/schema.graphql
@@ -38,6 +38,7 @@ enum ContentType {
   EMBED
   HTML
   IMAGE
+  PAGE_BREAK
   VIDEO
 }
 
@@ -1080,10 +1081,12 @@ type Mutation {
   deleteSkillNodeSimple(id: ID!): Boolean
   deleteSkillTree(id: ID!): SkillTree
   deleteUser(id: ID!): User
+  publishCourse(id: ID!): Course
   publishLessonBlock(id: ID!): LessonBlocks
   setUserRole(role: Role!, userId: ID!): User
   submitQuizAttempt(answers: [String!]!, quizId: ID!): QuizAttempt
   syncCurrentUser(name: String, photoUrl: String): User
+  unpublishCourse(id: ID!): Course
   updateCourse(id: ID!, input: UpdateCourseInput!): Course
   updateLessonBlock(input: LessonBlocksUpdateInput!): LessonBlocks
   updateQuiz(id: ID!, required: Boolean, title: String): Quiz

--- a/apps/client-frontend/src/components/LessonViewer.tsx
+++ b/apps/client-frontend/src/components/LessonViewer.tsx
@@ -1,14 +1,15 @@
-import React from "react";
+import React, { useState } from "react";
 import DOMPurify from "dompurify";
 import ReactPlayer from "react-player";
 import { useQuery } from "@apollo/client/react";
-import { ContentType } from "@synth-tree/api-types";
+import type { ContentType } from "@synth-tree/api-types";
 import { LESSON_BLOCKS_QUERY } from "../graphql/queries/lessonBlocks";
 
 interface LessonBlock {
   id: string;
   type: ContentType;
-  content: string;
+  html?: string | null;
+  url?: string | null;
   caption?: string | null;
   order: number;
 }
@@ -27,11 +28,29 @@ export const LessonViewer: React.FC<LessonViewerProps> = ({ nodeId, onNext }) =>
     variables: { nodeId },
   });
 
+  const [currentPageIndex, setCurrentPageIndex] = useState(0);
+
   if (loading) return <div>Loading lesson...</div>;
   if (error) return <div>Error loading lesson.</div>;
   if (!data) return <div>No lesson data found.</div>;
 
   const blocks = [...data.lessonBlocks].sort((a, b) => a.order - b.order);
+
+  const pages = blocks.reduce<LessonBlock[][]>(
+    (acc, block) => {
+      if (block.type === "PAGE_BREAK") {
+        acc.push([]);
+        return acc;
+      }
+
+      acc[acc.length - 1].push(block);
+      return acc;
+    },
+    [[]],
+  );
+
+  const currentPageBlocks = pages[currentPageIndex] ?? [];
+  const isLastPage = currentPageIndex === pages.length - 1;
 
   const renderHTML = (html: string) => (
     <div
@@ -45,7 +64,7 @@ export const LessonViewer: React.FC<LessonViewerProps> = ({ nodeId, onNext }) =>
   const renderImage = (block: LessonBlock) => (
     <figure className="m-0 text-center">
       <img
-        src={block.content}
+        src={block.url ?? ""}
         alt={block.caption || "Lesson image"}
         className="max-w-full h-auto rounded-lg shadow-md"
       />
@@ -76,31 +95,53 @@ export const LessonViewer: React.FC<LessonViewerProps> = ({ nodeId, onNext }) =>
 
   const renderBlock = (block: LessonBlock) => {
     switch (block.type) {
-      case ContentType.Html:
-        return renderHTML(block.content);
-      case ContentType.Image:
+      case "HTML":
+  return renderHTML(block.html ?? "");
+      case "IMAGE":
         return renderImage(block);
-      case ContentType.Video:
-        return renderVideo(block.content);
-      case ContentType.Embed:
-        return renderEmbed(block.content);
+      case "VIDEO":
+  return renderVideo(block.url ?? "");
+      case "EMBED":
+  return renderEmbed(block.url ?? "");
       default:
         return null;
     }
   };
 
   return (
-    <div className="flex flex-col gap-8">
-      {blocks.map((block) => (
-        <div key={block.id}>{renderBlock(block)}</div>
+  <div className="flex flex-col gap-8">
+    <div className="flex gap-2" aria-label="Lesson progress">
+      {pages.map((_, index) => (
+        <div
+          key={index}
+          className={`h-2 flex-1 rounded-full ${
+            index <= currentPageIndex ? "bg-[#667eea]" : "bg-gray-200"
+          }`}
+        />
       ))}
+    </div>
 
-      <button
-        className="mt-8 px-8 py-3 bg-gradient-to-br from-[#667eea] to-[#764ba2] text-white font-semibold text-lg rounded-lg cursor-pointer transition-all shadow-lg hover:-translate-y-0.5 hover:shadow-xl active:translate-y-0"
-        onClick={onNext}
-      >
-        Next
-      </button>
+    <p className="text-sm text-gray-500">
+      Page {currentPageIndex + 1} of {pages.length}
+    </p>
+
+    {currentPageBlocks.map((block) => (
+      <div key={block.id}>{renderBlock(block)}</div>
+    ))}
+
+    <button
+      className="mt-8 px-8 py-3 bg-gradient-to-br from-[#667eea] to-[#764ba2] text-white font-semibold text-lg rounded-lg cursor-pointer transition-all shadow-lg hover:-translate-y-0.5 hover:shadow-xl active:translate-y-0"
+      onClick={() => {
+        if (currentPageIndex < pages.length - 1) {
+          setCurrentPageIndex(currentPageIndex + 1);
+          return;
+        }
+
+        onNext();
+      }}
+    >
+      {isLastPage ? "Next" : "Next Page"}
+    </button>
     </div>
   );
 };

--- a/packages/api-types/src/graphql.ts
+++ b/packages/api-types/src/graphql.ts
@@ -62,6 +62,7 @@ export type ContentType =
   | 'EMBED'
   | 'HTML'
   | 'IMAGE'
+  | 'PAGE_BREAK'
   | 'VIDEO';
 
 export type Course = {
@@ -1108,10 +1109,12 @@ export type Mutation = {
   deleteSkillNodeSimple?: Maybe<Scalars['Boolean']['output']>;
   deleteSkillTree?: Maybe<SkillTree>;
   deleteUser?: Maybe<User>;
+  publishCourse?: Maybe<Course>;
   publishLessonBlock?: Maybe<LessonBlocks>;
   setUserRole?: Maybe<User>;
   submitQuizAttempt?: Maybe<QuizAttempt>;
   syncCurrentUser?: Maybe<User>;
+  unpublishCourse?: Maybe<Course>;
   updateCourse?: Maybe<Course>;
   updateLessonBlock?: Maybe<LessonBlocks>;
   updateQuiz?: Maybe<Quiz>;
@@ -1219,6 +1222,11 @@ export type MutationDeleteUserArgs = {
 };
 
 
+export type MutationPublishCourseArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
 export type MutationPublishLessonBlockArgs = {
   id: Scalars['ID']['input'];
 };
@@ -1239,6 +1247,11 @@ export type MutationSubmitQuizAttemptArgs = {
 export type MutationSyncCurrentUserArgs = {
   name?: InputMaybe<Scalars['String']['input']>;
   photoUrl?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type MutationUnpublishCourseArgs = {
+  id: Scalars['ID']['input'];
 };
 
 
@@ -5649,6 +5662,11 @@ export type UuidWithAggregatesFilter = {
   notIn?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
+export type AdminGetAllCoursesQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type AdminGetAllCoursesQuery = { __typename?: 'Query', adminGetAllCourses?: Array<{ __typename?: 'Course', id: string, title: string, status: CourseStatus, updatedAt: any, author: { __typename?: 'User', id: string, name?: string | null } }> | null };
+
 export type GetMyCoursesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -5661,13 +5679,19 @@ export type DeleteCourseMutationVariables = Exact<{
 
 export type DeleteCourseMutation = { __typename?: 'Mutation', deleteCourse?: { __typename?: 'Course', id: string } | null };
 
-export type UpdateCourseMutationVariables = Exact<{
+export type PublishCourseMutationVariables = Exact<{
   id: Scalars['ID']['input'];
-  input: UpdateCourseInput;
 }>;
 
 
-export type UpdateCourseMutation = { __typename?: 'Mutation', updateCourse?: { __typename?: 'Course', id: string, status: CourseStatus } | null };
+export type PublishCourseMutation = { __typename?: 'Mutation', publishCourse?: { __typename?: 'Course', id: string, status: CourseStatus } | null };
+
+export type UnpublishCourseMutationVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type UnpublishCourseMutation = { __typename?: 'Mutation', unpublishCourse?: { __typename?: 'Course', id: string, status: CourseStatus } | null };
 
 export type CreateCourseMutationVariables = Exact<{
   input: CreateCourseInput;
@@ -5704,6 +5728,46 @@ export type PublicGetAllCoursesQueryVariables = Exact<{ [key: string]: never; }>
 export type PublicGetAllCoursesQuery = { __typename?: 'Query', publicGetAllCourses?: Array<{ __typename?: 'Course', id: string, title: string, description?: string | null, status: CourseStatus, trees: Array<{ __typename?: 'SkillTree', id: string, title: string, description?: string | null }> }> | null };
 
 
+export const AdminGetAllCoursesDocument = gql`
+    query AdminGetAllCourses {
+  adminGetAllCourses {
+    id
+    title
+    status
+    updatedAt
+    author {
+      id
+      name
+    }
+  }
+}
+    `;
+
+/**
+ * __useAdminGetAllCoursesQuery__
+ *
+ * To run a query within a React component, call `useAdminGetAllCoursesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useAdminGetAllCoursesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useAdminGetAllCoursesQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useAdminGetAllCoursesQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<AdminGetAllCoursesQuery, AdminGetAllCoursesQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useQuery<AdminGetAllCoursesQuery, AdminGetAllCoursesQueryVariables>(AdminGetAllCoursesDocument, options);
+      }
+export function useAdminGetAllCoursesLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<AdminGetAllCoursesQuery, AdminGetAllCoursesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useLazyQuery<AdminGetAllCoursesQuery, AdminGetAllCoursesQueryVariables>(AdminGetAllCoursesDocument, options);
+        }
+export type AdminGetAllCoursesQueryHookResult = ReturnType<typeof useAdminGetAllCoursesQuery>;
+export type AdminGetAllCoursesLazyQueryHookResult = ReturnType<typeof useAdminGetAllCoursesLazyQuery>;
 export const GetMyCoursesDocument = gql`
     query GetMyCourses {
   adminMyCoursesWithContent(limit: 1) {
@@ -5768,9 +5832,9 @@ export function useDeleteCourseMutation(baseOptions?: ApolloReactHooks.MutationH
         return ApolloReactHooks.useMutation<DeleteCourseMutation, DeleteCourseMutationVariables>(DeleteCourseDocument, options);
       }
 export type DeleteCourseMutationHookResult = ReturnType<typeof useDeleteCourseMutation>;
-export const UpdateCourseDocument = gql`
-    mutation UpdateCourse($id: ID!, $input: UpdateCourseInput!) {
-  updateCourse(id: $id, input: $input) {
+export const PublishCourseDocument = gql`
+    mutation PublishCourse($id: ID!) {
+  publishCourse(id: $id) {
     id
     status
   }
@@ -5778,28 +5842,58 @@ export const UpdateCourseDocument = gql`
     `;
 
 /**
- * __useUpdateCourseMutation__
+ * __usePublishCourseMutation__
  *
- * To run a mutation, you first call `useUpdateCourseMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useUpdateCourseMutation` returns a tuple that includes:
+ * To run a mutation, you first call `usePublishCourseMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `usePublishCourseMutation` returns a tuple that includes:
  * - A mutate function that you can call at any time to execute the mutation
  * - An object with fields that represent the current status of the mutation's execution
  *
  * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
  *
  * @example
- * const [updateCourseMutation, { data, loading, error }] = useUpdateCourseMutation({
+ * const [publishCourseMutation, { data, loading, error }] = usePublishCourseMutation({
  *   variables: {
  *      id: // value for 'id'
- *      input: // value for 'input'
  *   },
  * });
  */
-export function useUpdateCourseMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<UpdateCourseMutation, UpdateCourseMutationVariables>) {
+export function usePublishCourseMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<PublishCourseMutation, PublishCourseMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return ApolloReactHooks.useMutation<UpdateCourseMutation, UpdateCourseMutationVariables>(UpdateCourseDocument, options);
+        return ApolloReactHooks.useMutation<PublishCourseMutation, PublishCourseMutationVariables>(PublishCourseDocument, options);
       }
-export type UpdateCourseMutationHookResult = ReturnType<typeof useUpdateCourseMutation>;
+export type PublishCourseMutationHookResult = ReturnType<typeof usePublishCourseMutation>;
+export const UnpublishCourseDocument = gql`
+    mutation UnpublishCourse($id: ID!) {
+  unpublishCourse(id: $id) {
+    id
+    status
+  }
+}
+    `;
+
+/**
+ * __useUnpublishCourseMutation__
+ *
+ * To run a mutation, you first call `useUnpublishCourseMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUnpublishCourseMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [unpublishCourseMutation, { data, loading, error }] = useUnpublishCourseMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useUnpublishCourseMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<UnpublishCourseMutation, UnpublishCourseMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useMutation<UnpublishCourseMutation, UnpublishCourseMutationVariables>(UnpublishCourseDocument, options);
+      }
+export type UnpublishCourseMutationHookResult = ReturnType<typeof useUnpublishCourseMutation>;
 export const CreateCourseDocument = gql`
     mutation CreateCourse($input: CreateCourseInput!) {
   createCourse(input: $input) {
@@ -5988,48 +6082,3 @@ export function usePublicGetAllCoursesLazyQuery(baseOptions?: ApolloReactHooks.L
         }
 export type PublicGetAllCoursesQueryHookResult = ReturnType<typeof usePublicGetAllCoursesQuery>;
 export type PublicGetAllCoursesLazyQueryHookResult = ReturnType<typeof usePublicGetAllCoursesLazyQuery>;
-
-export type AdminGetAllCoursesQueryVariables = Exact<{ [key: string]: never; }>;
-
-export type AdminGetAllCoursesQuery = { __typename?: 'Query', adminGetAllCourses?: Array<{ __typename?: 'Course', id: string, title: string, status: CourseStatus, updatedAt: string, author: { __typename?: 'User', id: string, name?: string | null } }> | null };
-
-export const AdminGetAllCoursesDocument = gql`
-    query AdminGetAllCourses {
-  adminGetAllCourses {
-    id
-    title
-    status
-    updatedAt
-    author {
-      id
-      name
-    }
-  }
-}
-    `;
-
-/**
- * __useAdminGetAllCoursesQuery__
- *
- * To run a query within a React component, call `useAdminGetAllCoursesQuery` and pass it any options that fit your needs.
- * When your component renders, `useAdminGetAllCoursesQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useAdminGetAllCoursesQuery({
- *   variables: {
- *   },
- * });
- */
-export function useAdminGetAllCoursesQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<AdminGetAllCoursesQuery, AdminGetAllCoursesQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return ApolloReactHooks.useQuery<AdminGetAllCoursesQuery, AdminGetAllCoursesQueryVariables>(AdminGetAllCoursesDocument, options);
-      }
-export function useAdminGetAllCoursesLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<AdminGetAllCoursesQuery, AdminGetAllCoursesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return ApolloReactHooks.useLazyQuery<AdminGetAllCoursesQuery, AdminGetAllCoursesQueryVariables>(AdminGetAllCoursesDocument, options);
-        }
-export type AdminGetAllCoursesQueryHookResult = ReturnType<typeof useAdminGetAllCoursesQuery>;
-export type AdminGetAllCoursesLazyQueryHookResult = ReturnType<typeof useAdminGetAllCoursesLazyQuery>;


### PR DESCRIPTION
## ⚠️ Jira Task

**Jira Task ID:** SYN-60
**Jira Link:** [[SYN-60](https://tripleten.atlassian.net/browse/SYN-60)](https://tripleten.atlassian.net/browse/SYN-60)

---

## ⚠️ Description

### What changes were made?

Implemented multi-page lesson support by introducing a new `PAGE_BREAK` content type.

The Prisma schema was updated to include the new content type and a migration was created and applied. GraphQL schema and generated API types were regenerated to expose the new enum value throughout the application.

The `LessonViewer` component was updated to:

* Split lesson blocks into pages using `PAGE_BREAK` blocks
* Render only the blocks belonging to the current page
* Add page navigation using a "Next Page" flow
* Display a page-based progress indicator
* Correctly render lesson content using the existing `html` and `url` fields returned by the API

### Why were these changes necessary?

Lessons previously rendered all lesson blocks on a single page. This change allows lessons to be divided into multiple pages while keeping the existing lesson block architecture intact.

Using a `PAGE_BREAK` content type follows the recommended design approach for the ticket and minimizes schema complexity compared to introducing a separate LessonPage model.

---

## ⚠️ Type of Change

* [x] 🎨 New Feature
* [ ] 🐛 Bug Fix
* [ ] 📝 Documentation Update
* [ ] ♻️ Code Refactor
* [ ] ⚡ Performance Improvement
* [ ] ✅ Test Addition/Update
* [ ] 🔧 Configuration Change
* [ ] 🗑️ Code Removal

---

## ⚠️ Changes Made

* Added `PAGE_BREAK` to the `ContentType` enum in Prisma
* Created and applied a Prisma migration for the new content type
* Regenerated GraphQL schema and generated API types
* Updated `LessonViewer` to support page splitting and page navigation
* Added a page-based progress indicator for lesson progression
* Fixed lesson block rendering to use API-provided `html` and `url` fields

---

## ⚠️ Testing

### Testing Steps

1. Applied the Prisma migration locally
2. Regenerated GraphQL schema and generated types
3. Ran client type checking
4. Ran client production build
5. Verified lesson blocks are grouped into pages using `PAGE_BREAK`
6. Verified page navigation advances through lesson pages correctly
7. Verified the progress indicator updates as pages change

### Test Results

All checks completed successfully.

* Prisma migration applied successfully
* GraphQL schema regenerated successfully
* Generated API types updated successfully
* Client type-check passed
* Client production build passed

### Browser/Environment Tested

* Windows 11
* Node.js 22
* pnpm 10
* Chrome

---

## Screenshots/Videos (if applicable)

### Before

Lessons rendered all blocks on a single page.

### After

Lessons are split into multiple pages using `PAGE_BREAK` blocks and display page-based progress.

---

## ⚠️ Pre-Submission Checklist

* [x] ✅ My code follows the project's style conventions and guidelines
* [x] ✅ I have performed a self-review of my own code
* [ ] ✅ I have commented my code, particularly in hard-to-understand areas
* [x] ✅ My branch is up to date with `main`
* [x] ✅ I have used descriptive commit messages
* [x] ✅ I have tested my changes thoroughly
* [x] ✅ All existing tests pass with my changes
* [ ] ✅ I have added tests that prove my fix is effective or that my feature works
* [ ] ✅ I have updated documentation (if needed)
* [x] ✅ My changes generate no new warnings or errors
* [x] ✅ My branch name follows the convention: `feature/SYN-XXX-description` or `bugfix/SYN-XXX-description`

---

## Additional Notes

This implementation follows the ticket recommendation of using a `PAGE_BREAK` content type instead of introducing a separate LessonPage model, reducing schema churn while enabling multi-page lesson support.

---

## Review Checklist (For Reviewers)

* [ ] Code quality and style are consistent
* [ ] Changes align with the Jira task requirements
* [ ] Tests are sufficient and passing
* [ ] Documentation is updated
* [ ] No security vulnerabilities introduced
* [ ] Performance impact is acceptable