### PR TITLE
Demo enablement: seed + learner login + lesson/quiz flow (+ fix #75 schema build)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,6 +18,7 @@
     "create:user": "ts-node -r tsconfig-paths/register scripts/createLocalUser.ts",
     "refresh:token": "ts-node -r tsconfig-paths/register scripts/refreshLocalToken.ts",
     "db:seed:local-users": "ts-node -r tsconfig-paths/register scripts/seedLocalUsers.ts",
+    "db:seed:demo": "ts-node -r tsconfig-paths/register scripts/seedDemoContent.ts",
     "test": "jest",
     "test:integration": "jest --testPathPattern=integration",
     "type-check": "tsc -p tsconfig.json --noEmit"

--- a/apps/api/scripts/seedDemoContent.ts
+++ b/apps/api/scripts/seedDemoContent.ts
@@ -1,0 +1,439 @@
+#!/usr/bin/env ts-node
+/**
+ * Seed realistic demo CONTENT (courses → trees → nodes → lessons → quizzes,
+ * plus some learner progress) for local development and the cohort demo.
+ *
+ * Idempotent: it removes any content owned by the synthetic demo author and
+ * recreates it from scratch, so re-running gives the same clean dataset.
+ *
+ * This is content only — it does NOT create auth/Firebase users. Run the user
+ * seed first if you want to log in:
+ *   pnpm db:seed:local-users   # creates admin@local.dev + learner@local.dev
+ *   pnpm db:seed:demo          # this script
+ *
+ * The demo courses are authored by a synthetic "Demo Author" user. Admins see
+ * and manage all courses (admin bypasses ownership checks), so you can publish/
+ * unpublish/delete these while logged in as admin@local.dev. If learner@local.dev
+ * exists, a little progress is seeded for them so the "Recommended next" carousel
+ * and progress have data.
+ */
+
+import "dotenv/config";
+
+import {
+  ContentType,
+  LessonStatus,
+  QuestionType,
+  CourseStatus,
+  ProgressStatus,
+  Role,
+} from "@prisma/client";
+
+import { prisma } from "../src/lib/prisma";
+
+// Stable id for the synthetic author so re-runs are idempotent (delete-by-author).
+const DEMO_AUTHOR_ID = "demo-author";
+const DEMO_AUTHOR_EMAIL = "demo-author@local.dev";
+const LEARNER_EMAIL = "learner@local.dev";
+
+type LessonSeed = {
+  type: ContentType;
+  html?: string;
+  url?: string;
+  caption?: string;
+};
+
+type QuestionSeed = {
+  type: QuestionType;
+  prompt: string;
+  options?: { text: string; isCorrect?: boolean }[];
+};
+
+type NodeSeed = {
+  title: string;
+  step: number;
+  orderInStep: number;
+  lessons: LessonSeed[];
+  quiz?: { title: string; required?: boolean; questions: QuestionSeed[] };
+  /** indices (within this tree's node list) this node depends on */
+  prereqs?: number[];
+};
+
+type CourseSeed = {
+  title: string;
+  description: string;
+  status: CourseStatus;
+  tree?: { title: string; description: string; nodes: NodeSeed[] };
+};
+
+const COURSES: CourseSeed[] = [
+  {
+    title: "Organic Chemistry",
+    description:
+      "Master the fundamentals of organic chemistry — structure, bonding, and reactions — through a guided path of theory and quizzes.",
+    status: CourseStatus.PUBLISHED,
+    tree: {
+      title: "Foundations of Organic Chemistry",
+      description: "Work from atoms and bonds up to your first named reactions.",
+      nodes: [
+        {
+          title: "Atoms & Bonding",
+          step: 1,
+          orderInStep: 0,
+          lessons: [
+            {
+              type: ContentType.HTML,
+              html: "<h2>Atoms &amp; Bonding</h2><p>Organic chemistry is the study of carbon-based molecules. We start with the <strong>covalent bond</strong>: two atoms sharing a pair of electrons.</p><ul><li>Carbon forms four bonds.</li><li>Bonds can be single, double, or triple.</li></ul>",
+            },
+            {
+              type: ContentType.VIDEO,
+              url: "https://www.youtube.com/watch?v=FSyAehMdpyI",
+              caption: "Introduction to covalent bonding",
+            },
+          ],
+          quiz: {
+            title: "Atoms & Bonding — quick check",
+            required: true,
+            questions: [
+              {
+                type: QuestionType.SINGLE_CHOICE,
+                prompt: "How many covalent bonds does a neutral carbon atom form?",
+                options: [
+                  { text: "2" },
+                  { text: "4", isCorrect: true },
+                  { text: "6" },
+                ],
+              },
+              {
+                type: QuestionType.MULTIPLE_CHOICE,
+                prompt: "Which of these are types of covalent bonds? (select all)",
+                options: [
+                  { text: "Single", isCorrect: true },
+                  { text: "Double", isCorrect: true },
+                  { text: "Magnetic" },
+                  { text: "Triple", isCorrect: true },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          title: "Functional Groups",
+          step: 1,
+          orderInStep: 1,
+          lessons: [
+            {
+              type: ContentType.HTML,
+              html: "<h2>Functional Groups</h2><p>A <strong>functional group</strong> is a specific arrangement of atoms that gives a molecule its characteristic reactions — e.g. hydroxyl (-OH), carbonyl (C=O), and carboxyl (-COOH).</p>",
+            },
+          ],
+        },
+        {
+          title: "Isomerism",
+          step: 2,
+          orderInStep: 0,
+          prereqs: [0, 1],
+          lessons: [
+            {
+              type: ContentType.HTML,
+              html: "<h2>Isomerism</h2><p><strong>Isomers</strong> share a molecular formula but differ in structure. Structural isomers differ in connectivity; stereoisomers differ in spatial arrangement.</p>",
+            },
+          ],
+          quiz: {
+            title: "Isomerism — reflection",
+            required: false,
+            questions: [
+              {
+                type: QuestionType.OPEN_QUESTION,
+                prompt:
+                  "In your own words, explain the difference between a structural isomer and a stereoisomer.",
+              },
+            ],
+          },
+        },
+        {
+          title: "Your First Reaction",
+          step: 3,
+          orderInStep: 0,
+          prereqs: [2],
+          lessons: [
+            {
+              type: ContentType.HTML,
+              html: "<h2>Your First Reaction</h2><p>Substitution, addition, and elimination are the three reaction families you'll meet first. We'll trace electrons through each.</p>",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    title: "Foundations of Physics",
+    description:
+      "Build intuition for motion, forces, and energy with bite-sized lessons and checkpoints.",
+    status: CourseStatus.PUBLISHED,
+    tree: {
+      title: "Classical Mechanics Basics",
+      description: "From kinematics to conservation of energy.",
+      nodes: [
+        {
+          title: "Kinematics",
+          step: 1,
+          orderInStep: 0,
+          lessons: [
+            {
+              type: ContentType.HTML,
+              html: "<h2>Kinematics</h2><p>Kinematics describes motion: position, velocity, and acceleration — without yet asking <em>why</em> things move.</p>",
+            },
+          ],
+          quiz: {
+            title: "Kinematics — quick check",
+            required: true,
+            questions: [
+              {
+                type: QuestionType.SINGLE_CHOICE,
+                prompt: "Velocity is the rate of change of…",
+                options: [
+                  { text: "Position", isCorrect: true },
+                  { text: "Acceleration" },
+                  { text: "Mass" },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          title: "Newton's Laws",
+          step: 2,
+          orderInStep: 0,
+          prereqs: [0],
+          lessons: [
+            {
+              type: ContentType.HTML,
+              html: "<h2>Newton's Laws</h2><p>Three laws connect force and motion. The second, <strong>F = ma</strong>, is the workhorse of mechanics.</p>",
+            },
+          ],
+        },
+        {
+          title: "Energy & Work",
+          step: 3,
+          orderInStep: 0,
+          prereqs: [1],
+          lessons: [
+            {
+              type: ContentType.HTML,
+              html: "<h2>Energy &amp; Work</h2><p>Work transfers energy. In a closed system, total mechanical energy is conserved.</p>",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    title: "Cell Biology",
+    description:
+      "Explore the building blocks of life — from organelles to the processes that keep cells alive.",
+    status: CourseStatus.PUBLISHED,
+    tree: {
+      title: "Inside the Cell",
+      description: "A tour of the eukaryotic cell.",
+      nodes: [
+        {
+          title: "The Cell Membrane",
+          step: 1,
+          orderInStep: 0,
+          lessons: [
+            {
+              type: ContentType.HTML,
+              html: "<h2>The Cell Membrane</h2><p>The phospholipid bilayer is selectively permeable, controlling what enters and leaves the cell.</p>",
+            },
+          ],
+        },
+        {
+          title: "Organelles",
+          step: 2,
+          orderInStep: 0,
+          prereqs: [0],
+          lessons: [
+            {
+              type: ContentType.HTML,
+              html: "<h2>Organelles</h2><p>The nucleus, mitochondria, and ER each play a specialized role — like rooms in a factory.</p>",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    title: "Linear Algebra",
+    description: "Vectors, matrices, and transformations. (In development.)",
+    status: CourseStatus.DRAFT,
+    tree: {
+      title: "Vectors & Matrices",
+      description: "Draft outline.",
+      nodes: [
+        {
+          title: "Vectors",
+          step: 1,
+          orderInStep: 0,
+          lessons: [
+            {
+              type: ContentType.HTML,
+              html: "<h2>Vectors</h2><p>Draft lesson — coming soon.</p>",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    title: "Web Accessibility",
+    description: "Build interfaces everyone can use. (In development.)",
+    status: CourseStatus.DRAFT,
+  },
+];
+
+async function main() {
+  console.log("➡️  Seeding demo content…");
+
+  // 1. Synthetic author (admins can manage these courses regardless of author).
+  const author = await prisma.user.upsert({
+    where: { id: DEMO_AUTHOR_ID },
+    update: {},
+    create: {
+      id: DEMO_AUTHOR_ID,
+      email: DEMO_AUTHOR_EMAIL,
+      name: "Demo Author",
+      role: Role.ADMIN,
+    },
+  });
+
+  // 2. Clean any prior demo content (cascades to trees/nodes/lessons/quizzes/progress).
+  const removed = await prisma.course.deleteMany({ where: { authorId: author.id } });
+  if (removed.count) console.log(`   cleaned ${removed.count} existing demo course(s)`);
+
+  // Collect the node ids of the flagship course so we can seed learner progress.
+  let flagshipNodeIds: string[] = [];
+
+  for (const c of COURSES) {
+    const course = await prisma.course.create({
+      data: {
+        title: c.title,
+        description: c.description,
+        status: c.status,
+        authorId: author.id,
+      },
+    });
+
+    if (!c.tree) {
+      console.log(`   • ${c.title} (${c.status})`);
+      continue;
+    }
+
+    const tree = await prisma.skillTree.create({
+      data: { courseId: course.id, title: c.tree.title, description: c.tree.description },
+    });
+
+    // Create nodes first (so prerequisites can reference real ids), with
+    // distinct posX/posY to satisfy @@unique([treeId, posX, posY]).
+    const nodeIds: string[] = [];
+    for (const n of c.tree.nodes) {
+      const node = await prisma.skillNode.create({
+        data: {
+          treeId: tree.id,
+          title: n.title,
+          step: n.step,
+          orderInStep: n.orderInStep,
+          posX: n.orderInStep * 200,
+          posY: n.step * 200,
+        },
+      });
+      nodeIds.push(node.id);
+
+      // Lessons
+      await prisma.lessonBlocks.createMany({
+        data: n.lessons.map((l, i) => ({
+          nodeId: node.id,
+          type: l.type,
+          html: l.html ?? null,
+          url: l.url ?? null,
+          caption: l.caption ?? null,
+          order: i,
+          status: LessonStatus.PUBLISHED,
+        })),
+      });
+
+      // Quiz + questions + options
+      if (n.quiz) {
+        const quiz = await prisma.quiz.create({
+          data: { nodeId: node.id, title: n.quiz.title, required: n.quiz.required ?? false },
+        });
+        for (let qi = 0; qi < n.quiz.questions.length; qi++) {
+          const q = n.quiz.questions[qi];
+          const question = await prisma.quizQuestion.create({
+            data: { quizId: quiz.id, type: q.type, prompt: q.prompt, order: qi },
+          });
+          if (q.options?.length) {
+            await prisma.quizOption.createMany({
+              data: q.options.map((o) => ({
+                questionId: question.id,
+                text: o.text,
+                isCorrect: o.isCorrect ?? false,
+              })),
+            });
+          }
+        }
+      }
+    }
+
+    // Prerequisites (gating) now that all node ids exist.
+    for (let i = 0; i < c.tree.nodes.length; i++) {
+      for (const dep of c.tree.nodes[i].prereqs ?? []) {
+        await prisma.skillNodePrerequisite.create({
+          data: { nodeId: nodeIds[i], dependsOnNodeId: nodeIds[dep] },
+        });
+      }
+    }
+
+    if (c.title === "Organic Chemistry") flagshipNodeIds = nodeIds;
+    console.log(`   • ${c.title} (${c.status}) — ${c.tree.nodes.length} node(s)`);
+  }
+
+  // 3. Seed a little progress for the real local learner (if it exists), so the
+  //    "Recommended next" carousel and progress have realistic data on login.
+  const learner = await prisma.user.findUnique({ where: { email: LEARNER_EMAIL } });
+  if (learner && flagshipNodeIds.length >= 2) {
+    await prisma.userNodeProgress.upsert({
+      where: { userId_nodeId: { userId: learner.id, nodeId: flagshipNodeIds[0] } },
+      update: { status: ProgressStatus.COMPLETED, completedAt: new Date() },
+      create: {
+        userId: learner.id,
+        nodeId: flagshipNodeIds[0],
+        status: ProgressStatus.COMPLETED,
+        completedAt: new Date(),
+      },
+    });
+    await prisma.userNodeProgress.upsert({
+      where: { userId_nodeId: { userId: learner.id, nodeId: flagshipNodeIds[1] } },
+      update: { status: ProgressStatus.IN_PROGRESS },
+      create: {
+        userId: learner.id,
+        nodeId: flagshipNodeIds[1],
+        status: ProgressStatus.IN_PROGRESS,
+      },
+    });
+    console.log(`   • seeded progress for ${LEARNER_EMAIL}`);
+  } else {
+    console.log(
+      `   • (skipped learner progress — run 'pnpm db:seed:local-users' first to create ${LEARNER_EMAIL})`,
+    );
+  }
+
+  console.log("✅ Demo content seeded.");
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/apps/api/src/graphql/models/models.all.ts
+++ b/apps/api/src/graphql/models/models.all.ts
@@ -13,6 +13,9 @@ import { QuizOptionObject } from "@graphql/__generated__/QuizOption";
 import { QuizAttemptObject } from "@graphql/__generated__/QuizAttempt";
 import { QuizAttemptAnswerObject } from "@graphql/__generated__/QuizAttemptAnswer";
 import { UserNodeProgressObject } from "@graphql/__generated__/UserNodeProgress";
+import { UserXpObject } from "@graphql/__generated__/UserXp";
+import { UserStreakObject } from "@graphql/__generated__/UserStreak";
+import { XpEventObject } from "@graphql/__generated__/XpEvent";
 
 // We are not using the auto crud from pothos. Utilize the prisma models. Inputs types and other types will still need to be manually created.
 // Can break this file into multiple. Used one now for brevity.
@@ -85,6 +88,11 @@ builder.prismaObject("QuizOption", QuizOptionObject);
 builder.prismaObject("QuizAttempt", QuizAttemptObject);
 builder.prismaObject("QuizAttemptAnswer", QuizAttemptAnswerObject);
 builder.prismaObject("UserNodeProgress", UserNodeProgressObject);
+// XP / streak models (added in #75). The User object exposes relations to these,
+// so the schema build requires them to be implemented here.
+builder.prismaObject("UserXp", UserXpObject);
+builder.prismaObject("UserStreak", UserStreakObject);
+builder.prismaObject("XpEvent", XpEventObject);
 
 export type CourseProgressShape = {
   courseId: string;

--- a/apps/api/src/graphql/schema.graphql
+++ b/apps/api/src/graphql/schema.graphql
@@ -663,9 +663,30 @@ input IntWithAggregatesFilter {
 
 scalar Json
 
+input JsonFilter {
+  array_contains: Json
+  array_ends_with: Json
+  array_starts_with: Json
+  equals: Json
+  gt: Json
+  gte: Json
+  lt: Json
+  lte: Json
+  mode: QueryMode
+  not: Json
+  path: [String!]
+  string_contains: String
+  string_ends_with: String
+  string_starts_with: String
+}
+
 enum JsonNullValueFilter {
   AnyNull
   DbNull
+  JsonNull
+}
+
+enum JsonNullValueInput {
   JsonNull
 }
 
@@ -690,6 +711,26 @@ input JsonNullableWithAggregatesFilter {
   _count: NestedIntNullableFilter
   _max: NestedJsonNullableFilter
   _min: NestedJsonNullableFilter
+  array_contains: Json
+  array_ends_with: Json
+  array_starts_with: Json
+  equals: Json
+  gt: Json
+  gte: Json
+  lt: Json
+  lte: Json
+  mode: QueryMode
+  not: Json
+  path: [String!]
+  string_contains: String
+  string_ends_with: String
+  string_starts_with: String
+}
+
+input JsonWithAggregatesFilter {
+  _count: NestedIntFilter
+  _max: NestedJsonFilter
+  _min: NestedJsonFilter
   array_contains: Json
   array_ends_with: Json
   array_starts_with: Json
@@ -1083,6 +1124,7 @@ type Mutation {
   publishCourse(id: ID!): Course
   publishLessonBlock(id: ID!): LessonBlocks
   setUserRole(role: Role!, userId: ID!): User
+  startNodeProgress(nodeId: ID!): UserNodeProgress
   submitQuizAttempt(answers: [String!]!, quizId: ID!): QuizAttempt
   syncCurrentUser(name: String, photoUrl: String): User
   unpublishCourse(id: ID!): Course
@@ -1350,6 +1392,23 @@ input NestedIntWithAggregatesFilter {
   lte: Int
   not: NestedIntWithAggregatesFilter
   notIn: [Int!]
+}
+
+input NestedJsonFilter {
+  array_contains: Json
+  array_ends_with: Json
+  array_starts_with: Json
+  equals: Json
+  gt: Json
+  gte: Json
+  lt: Json
+  lte: Json
+  mode: QueryMode
+  not: Json
+  path: [String!]
+  string_contains: String
+  string_ends_with: String
+  string_starts_with: String
 }
 
 input NestedJsonNullableFilter {
@@ -4491,7 +4550,10 @@ type User {
   quizAttempts(cursor: QuizAttemptWhereUniqueInput, distinct: [QuizAttemptScalarFieldEnum!], orderBy: [QuizAttemptOrderByWithRelationInput!], skip: Int, take: Int, where: QuizAttemptWhereInput): [QuizAttempt!]!
   recommendedNext(limit: Int = 6): [SkillNode!]
   role: Role!
+  streak: UserStreak
   updatedAt: DateTime!
+  xp: UserXp
+  xpEvents(cursor: XpEventWhereUniqueInput, distinct: [XpEventScalarFieldEnum!], orderBy: [XpEventOrderByWithRelationInput!], skip: Int, take: Int, where: XpEventWhereInput): [XpEvent!]!
 }
 
 input UserCountOrderByAggregateInput {
@@ -4514,7 +4576,10 @@ input UserCreateInput {
   photoUrl: String
   quizAttempts: QuizAttemptCreateNestedManyWithoutUserInput
   role: Role
+  streak: UserStreakCreateNestedOneWithoutUserInput
   updatedAt: DateTime
+  xp: UserXpCreateNestedOneWithoutUserInput
+  xpEvents: XpEventCreateNestedManyWithoutUserInput
 }
 
 input UserCreateManyInput {
@@ -4545,6 +4610,24 @@ input UserCreateNestedOneWithoutQuizAttemptsInput {
   create: UserCreateWithoutQuizAttemptsInput
 }
 
+input UserCreateNestedOneWithoutStreakInput {
+  connect: UserWhereUniqueInput
+  connectOrCreate: UserCreateOrConnectWithoutStreakInput
+  create: UserCreateWithoutStreakInput
+}
+
+input UserCreateNestedOneWithoutXpEventsInput {
+  connect: UserWhereUniqueInput
+  connectOrCreate: UserCreateOrConnectWithoutXpEventsInput
+  create: UserCreateWithoutXpEventsInput
+}
+
+input UserCreateNestedOneWithoutXpInput {
+  connect: UserWhereUniqueInput
+  connectOrCreate: UserCreateOrConnectWithoutXpInput
+  create: UserCreateWithoutXpInput
+}
+
 input UserCreateOrConnectWithoutCoursesAuthoredInput {
   create: UserCreateWithoutCoursesAuthoredInput!
   where: UserWhereUniqueInput!
@@ -4560,6 +4643,21 @@ input UserCreateOrConnectWithoutQuizAttemptsInput {
   where: UserWhereUniqueInput!
 }
 
+input UserCreateOrConnectWithoutStreakInput {
+  create: UserCreateWithoutStreakInput!
+  where: UserWhereUniqueInput!
+}
+
+input UserCreateOrConnectWithoutXpEventsInput {
+  create: UserCreateWithoutXpEventsInput!
+  where: UserWhereUniqueInput!
+}
+
+input UserCreateOrConnectWithoutXpInput {
+  create: UserCreateWithoutXpInput!
+  where: UserWhereUniqueInput!
+}
+
 input UserCreateWithoutCoursesAuthoredInput {
   createdAt: DateTime
   email: String!
@@ -4569,7 +4667,10 @@ input UserCreateWithoutCoursesAuthoredInput {
   photoUrl: String
   quizAttempts: QuizAttemptCreateNestedManyWithoutUserInput
   role: Role
+  streak: UserStreakCreateNestedOneWithoutUserInput
   updatedAt: DateTime
+  xp: UserXpCreateNestedOneWithoutUserInput
+  xpEvents: XpEventCreateNestedManyWithoutUserInput
 }
 
 input UserCreateWithoutNodeProgressInput {
@@ -4581,7 +4682,10 @@ input UserCreateWithoutNodeProgressInput {
   photoUrl: String
   quizAttempts: QuizAttemptCreateNestedManyWithoutUserInput
   role: Role
+  streak: UserStreakCreateNestedOneWithoutUserInput
   updatedAt: DateTime
+  xp: UserXpCreateNestedOneWithoutUserInput
+  xpEvents: XpEventCreateNestedManyWithoutUserInput
 }
 
 input UserCreateWithoutQuizAttemptsInput {
@@ -4593,7 +4697,55 @@ input UserCreateWithoutQuizAttemptsInput {
   nodeProgress: UserNodeProgressCreateNestedManyWithoutUserInput
   photoUrl: String
   role: Role
+  streak: UserStreakCreateNestedOneWithoutUserInput
   updatedAt: DateTime
+  xp: UserXpCreateNestedOneWithoutUserInput
+  xpEvents: XpEventCreateNestedManyWithoutUserInput
+}
+
+input UserCreateWithoutStreakInput {
+  coursesAuthored: CourseCreateNestedManyWithoutAuthorInput
+  createdAt: DateTime
+  email: String!
+  id: String!
+  name: String
+  nodeProgress: UserNodeProgressCreateNestedManyWithoutUserInput
+  photoUrl: String
+  quizAttempts: QuizAttemptCreateNestedManyWithoutUserInput
+  role: Role
+  updatedAt: DateTime
+  xp: UserXpCreateNestedOneWithoutUserInput
+  xpEvents: XpEventCreateNestedManyWithoutUserInput
+}
+
+input UserCreateWithoutXpEventsInput {
+  coursesAuthored: CourseCreateNestedManyWithoutAuthorInput
+  createdAt: DateTime
+  email: String!
+  id: String!
+  name: String
+  nodeProgress: UserNodeProgressCreateNestedManyWithoutUserInput
+  photoUrl: String
+  quizAttempts: QuizAttemptCreateNestedManyWithoutUserInput
+  role: Role
+  streak: UserStreakCreateNestedOneWithoutUserInput
+  updatedAt: DateTime
+  xp: UserXpCreateNestedOneWithoutUserInput
+}
+
+input UserCreateWithoutXpInput {
+  coursesAuthored: CourseCreateNestedManyWithoutAuthorInput
+  createdAt: DateTime
+  email: String!
+  id: String!
+  name: String
+  nodeProgress: UserNodeProgressCreateNestedManyWithoutUserInput
+  photoUrl: String
+  quizAttempts: QuizAttemptCreateNestedManyWithoutUserInput
+  role: Role
+  streak: UserStreakCreateNestedOneWithoutUserInput
+  updatedAt: DateTime
+  xpEvents: XpEventCreateNestedManyWithoutUserInput
 }
 
 input UserMaxOrderByAggregateInput {
@@ -4974,7 +5126,10 @@ input UserOrderByWithRelationInput {
   photoUrl: SortOrder
   quizAttempts: QuizAttemptOrderByRelationAggregateInput
   role: SortOrder
+  streak: UserStreakOrderByWithRelationInput
   updatedAt: SortOrder
+  xp: UserXpOrderByWithRelationInput
+  xpEvents: XpEventOrderByRelationAggregateInput
 }
 
 enum UserScalarFieldEnum {
@@ -5005,6 +5160,180 @@ input UserScalarWhereWithAggregatesInput {
   updatedAt: DateTimeWithAggregatesFilter
 }
 
+type UserStreak {
+  currentDays: Int!
+  lastActive: DateTime
+  longestDays: Int!
+  user: User!
+  userId: ID!
+}
+
+input UserStreakAvgOrderByAggregateInput {
+  currentDays: SortOrder
+  longestDays: SortOrder
+}
+
+input UserStreakCountOrderByAggregateInput {
+  currentDays: SortOrder
+  lastActive: SortOrder
+  longestDays: SortOrder
+  userId: SortOrder
+}
+
+input UserStreakCreateInput {
+  currentDays: Int
+  lastActive: DateTime
+  longestDays: Int
+  user: UserCreateNestedOneWithoutStreakInput!
+}
+
+input UserStreakCreateManyInput {
+  currentDays: Int
+  lastActive: DateTime
+  longestDays: Int
+  userId: String!
+}
+
+input UserStreakCreateNestedOneWithoutUserInput {
+  connect: UserStreakWhereUniqueInput
+  connectOrCreate: UserStreakCreateOrConnectWithoutUserInput
+  create: UserStreakCreateWithoutUserInput
+}
+
+input UserStreakCreateOrConnectWithoutUserInput {
+  create: UserStreakCreateWithoutUserInput!
+  where: UserStreakWhereUniqueInput!
+}
+
+input UserStreakCreateWithoutUserInput {
+  currentDays: Int
+  lastActive: DateTime
+  longestDays: Int
+}
+
+input UserStreakMaxOrderByAggregateInput {
+  currentDays: SortOrder
+  lastActive: SortOrder
+  longestDays: SortOrder
+  userId: SortOrder
+}
+
+input UserStreakMinOrderByAggregateInput {
+  currentDays: SortOrder
+  lastActive: SortOrder
+  longestDays: SortOrder
+  userId: SortOrder
+}
+
+input UserStreakNullableScalarRelationFilter {
+  is: UserStreakWhereInput
+  isNot: UserStreakWhereInput
+}
+
+input UserStreakOrderByWithAggregationInput {
+  _avg: UserStreakAvgOrderByAggregateInput
+  _count: UserStreakCountOrderByAggregateInput
+  _max: UserStreakMaxOrderByAggregateInput
+  _min: UserStreakMinOrderByAggregateInput
+  _sum: UserStreakSumOrderByAggregateInput
+  currentDays: SortOrder
+  lastActive: SortOrder
+  longestDays: SortOrder
+  userId: SortOrder
+}
+
+input UserStreakOrderByWithRelationInput {
+  currentDays: SortOrder
+  lastActive: SortOrder
+  longestDays: SortOrder
+  user: UserOrderByWithRelationInput
+  userId: SortOrder
+}
+
+enum UserStreakScalarFieldEnum {
+  currentDays
+  lastActive
+  longestDays
+  userId
+}
+
+input UserStreakScalarWhereWithAggregatesInput {
+  AND: [UserStreakScalarWhereWithAggregatesInput!]
+  NOT: [UserStreakScalarWhereWithAggregatesInput!]
+  OR: [UserStreakScalarWhereWithAggregatesInput!]
+  currentDays: IntWithAggregatesFilter
+  lastActive: DateTimeNullableWithAggregatesFilter
+  longestDays: IntWithAggregatesFilter
+  userId: StringWithAggregatesFilter
+}
+
+input UserStreakSumOrderByAggregateInput {
+  currentDays: SortOrder
+  longestDays: SortOrder
+}
+
+input UserStreakUpdateInput {
+  currentDays: IntFieldUpdateOperationsInput
+  lastActive: NullableDateTimeFieldUpdateOperationsInput
+  longestDays: IntFieldUpdateOperationsInput
+  user: UserUpdateOneRequiredWithoutStreakNestedInput
+}
+
+input UserStreakUpdateManyMutationInput {
+  currentDays: IntFieldUpdateOperationsInput
+  lastActive: NullableDateTimeFieldUpdateOperationsInput
+  longestDays: IntFieldUpdateOperationsInput
+}
+
+input UserStreakUpdateOneWithoutUserNestedInput {
+  connect: UserStreakWhereUniqueInput
+  connectOrCreate: UserStreakCreateOrConnectWithoutUserInput
+  create: UserStreakCreateWithoutUserInput
+  delete: UserStreakWhereInput
+  disconnect: UserStreakWhereInput
+  update: UserStreakUpdateToOneWithWhereWithoutUserInput
+  upsert: UserStreakUpsertWithoutUserInput
+}
+
+input UserStreakUpdateToOneWithWhereWithoutUserInput {
+  data: UserStreakUpdateWithoutUserInput!
+  where: UserStreakWhereInput
+}
+
+input UserStreakUpdateWithoutUserInput {
+  currentDays: IntFieldUpdateOperationsInput
+  lastActive: NullableDateTimeFieldUpdateOperationsInput
+  longestDays: IntFieldUpdateOperationsInput
+}
+
+input UserStreakUpsertWithoutUserInput {
+  create: UserStreakCreateWithoutUserInput!
+  update: UserStreakUpdateWithoutUserInput!
+  where: UserStreakWhereInput
+}
+
+input UserStreakWhereInput {
+  AND: [UserStreakWhereInput!]
+  NOT: [UserStreakWhereInput!]
+  OR: [UserStreakWhereInput!]
+  currentDays: IntFilter
+  lastActive: DateTimeNullableFilter
+  longestDays: IntFilter
+  user: UserWhereInput
+  userId: StringFilter
+}
+
+input UserStreakWhereUniqueInput {
+  AND: [UserStreakWhereInput!]
+  NOT: [UserStreakWhereInput!]
+  OR: [UserStreakWhereInput!]
+  currentDays: IntFilter
+  lastActive: DateTimeNullableFilter
+  longestDays: IntFilter
+  user: UserWhereInput
+  userId: String
+}
+
 input UserUpdateInput {
   coursesAuthored: CourseUpdateManyWithoutAuthorNestedInput
   createdAt: DateTimeFieldUpdateOperationsInput
@@ -5015,7 +5344,10 @@ input UserUpdateInput {
   photoUrl: NullableStringFieldUpdateOperationsInput
   quizAttempts: QuizAttemptUpdateManyWithoutUserNestedInput
   role: EnumRoleFieldUpdateOperationsInput
+  streak: UserStreakUpdateOneWithoutUserNestedInput
   updatedAt: DateTimeFieldUpdateOperationsInput
+  xp: UserXpUpdateOneWithoutUserNestedInput
+  xpEvents: XpEventUpdateManyWithoutUserNestedInput
 }
 
 input UserUpdateManyMutationInput {
@@ -5052,6 +5384,30 @@ input UserUpdateOneRequiredWithoutQuizAttemptsNestedInput {
   upsert: UserUpsertWithoutQuizAttemptsInput
 }
 
+input UserUpdateOneRequiredWithoutStreakNestedInput {
+  connect: UserWhereUniqueInput
+  connectOrCreate: UserCreateOrConnectWithoutStreakInput
+  create: UserCreateWithoutStreakInput
+  update: UserUpdateToOneWithWhereWithoutStreakInput
+  upsert: UserUpsertWithoutStreakInput
+}
+
+input UserUpdateOneRequiredWithoutXpEventsNestedInput {
+  connect: UserWhereUniqueInput
+  connectOrCreate: UserCreateOrConnectWithoutXpEventsInput
+  create: UserCreateWithoutXpEventsInput
+  update: UserUpdateToOneWithWhereWithoutXpEventsInput
+  upsert: UserUpsertWithoutXpEventsInput
+}
+
+input UserUpdateOneRequiredWithoutXpNestedInput {
+  connect: UserWhereUniqueInput
+  connectOrCreate: UserCreateOrConnectWithoutXpInput
+  create: UserCreateWithoutXpInput
+  update: UserUpdateToOneWithWhereWithoutXpInput
+  upsert: UserUpsertWithoutXpInput
+}
+
 input UserUpdateToOneWithWhereWithoutCoursesAuthoredInput {
   data: UserUpdateWithoutCoursesAuthoredInput!
   where: UserWhereInput
@@ -5067,6 +5423,21 @@ input UserUpdateToOneWithWhereWithoutQuizAttemptsInput {
   where: UserWhereInput
 }
 
+input UserUpdateToOneWithWhereWithoutStreakInput {
+  data: UserUpdateWithoutStreakInput!
+  where: UserWhereInput
+}
+
+input UserUpdateToOneWithWhereWithoutXpEventsInput {
+  data: UserUpdateWithoutXpEventsInput!
+  where: UserWhereInput
+}
+
+input UserUpdateToOneWithWhereWithoutXpInput {
+  data: UserUpdateWithoutXpInput!
+  where: UserWhereInput
+}
+
 input UserUpdateWithoutCoursesAuthoredInput {
   createdAt: DateTimeFieldUpdateOperationsInput
   email: StringFieldUpdateOperationsInput
@@ -5076,7 +5447,10 @@ input UserUpdateWithoutCoursesAuthoredInput {
   photoUrl: NullableStringFieldUpdateOperationsInput
   quizAttempts: QuizAttemptUpdateManyWithoutUserNestedInput
   role: EnumRoleFieldUpdateOperationsInput
+  streak: UserStreakUpdateOneWithoutUserNestedInput
   updatedAt: DateTimeFieldUpdateOperationsInput
+  xp: UserXpUpdateOneWithoutUserNestedInput
+  xpEvents: XpEventUpdateManyWithoutUserNestedInput
 }
 
 input UserUpdateWithoutNodeProgressInput {
@@ -5088,7 +5462,10 @@ input UserUpdateWithoutNodeProgressInput {
   photoUrl: NullableStringFieldUpdateOperationsInput
   quizAttempts: QuizAttemptUpdateManyWithoutUserNestedInput
   role: EnumRoleFieldUpdateOperationsInput
+  streak: UserStreakUpdateOneWithoutUserNestedInput
   updatedAt: DateTimeFieldUpdateOperationsInput
+  xp: UserXpUpdateOneWithoutUserNestedInput
+  xpEvents: XpEventUpdateManyWithoutUserNestedInput
 }
 
 input UserUpdateWithoutQuizAttemptsInput {
@@ -5100,7 +5477,55 @@ input UserUpdateWithoutQuizAttemptsInput {
   nodeProgress: UserNodeProgressUpdateManyWithoutUserNestedInput
   photoUrl: NullableStringFieldUpdateOperationsInput
   role: EnumRoleFieldUpdateOperationsInput
+  streak: UserStreakUpdateOneWithoutUserNestedInput
   updatedAt: DateTimeFieldUpdateOperationsInput
+  xp: UserXpUpdateOneWithoutUserNestedInput
+  xpEvents: XpEventUpdateManyWithoutUserNestedInput
+}
+
+input UserUpdateWithoutStreakInput {
+  coursesAuthored: CourseUpdateManyWithoutAuthorNestedInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  email: StringFieldUpdateOperationsInput
+  id: StringFieldUpdateOperationsInput
+  name: NullableStringFieldUpdateOperationsInput
+  nodeProgress: UserNodeProgressUpdateManyWithoutUserNestedInput
+  photoUrl: NullableStringFieldUpdateOperationsInput
+  quizAttempts: QuizAttemptUpdateManyWithoutUserNestedInput
+  role: EnumRoleFieldUpdateOperationsInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  xp: UserXpUpdateOneWithoutUserNestedInput
+  xpEvents: XpEventUpdateManyWithoutUserNestedInput
+}
+
+input UserUpdateWithoutXpEventsInput {
+  coursesAuthored: CourseUpdateManyWithoutAuthorNestedInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  email: StringFieldUpdateOperationsInput
+  id: StringFieldUpdateOperationsInput
+  name: NullableStringFieldUpdateOperationsInput
+  nodeProgress: UserNodeProgressUpdateManyWithoutUserNestedInput
+  photoUrl: NullableStringFieldUpdateOperationsInput
+  quizAttempts: QuizAttemptUpdateManyWithoutUserNestedInput
+  role: EnumRoleFieldUpdateOperationsInput
+  streak: UserStreakUpdateOneWithoutUserNestedInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  xp: UserXpUpdateOneWithoutUserNestedInput
+}
+
+input UserUpdateWithoutXpInput {
+  coursesAuthored: CourseUpdateManyWithoutAuthorNestedInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  email: StringFieldUpdateOperationsInput
+  id: StringFieldUpdateOperationsInput
+  name: NullableStringFieldUpdateOperationsInput
+  nodeProgress: UserNodeProgressUpdateManyWithoutUserNestedInput
+  photoUrl: NullableStringFieldUpdateOperationsInput
+  quizAttempts: QuizAttemptUpdateManyWithoutUserNestedInput
+  role: EnumRoleFieldUpdateOperationsInput
+  streak: UserStreakUpdateOneWithoutUserNestedInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  xpEvents: XpEventUpdateManyWithoutUserNestedInput
 }
 
 input UserUpsertWithoutCoursesAuthoredInput {
@@ -5121,6 +5546,24 @@ input UserUpsertWithoutQuizAttemptsInput {
   where: UserWhereInput
 }
 
+input UserUpsertWithoutStreakInput {
+  create: UserCreateWithoutStreakInput!
+  update: UserUpdateWithoutStreakInput!
+  where: UserWhereInput
+}
+
+input UserUpsertWithoutXpEventsInput {
+  create: UserCreateWithoutXpEventsInput!
+  update: UserUpdateWithoutXpEventsInput!
+  where: UserWhereInput
+}
+
+input UserUpsertWithoutXpInput {
+  create: UserCreateWithoutXpInput!
+  update: UserUpdateWithoutXpInput!
+  where: UserWhereInput
+}
+
 input UserWhereInput {
   AND: [UserWhereInput!]
   NOT: [UserWhereInput!]
@@ -5134,7 +5577,10 @@ input UserWhereInput {
   photoUrl: StringNullableFilter
   quizAttempts: QuizAttemptListRelationFilter
   role: EnumRoleFilter
+  streak: UserStreakWhereInput
   updatedAt: DateTimeFilter
+  xp: UserXpWhereInput
+  xpEvents: XpEventListRelationFilter
 }
 
 input UserWhereUniqueInput {
@@ -5150,7 +5596,198 @@ input UserWhereUniqueInput {
   photoUrl: StringNullableFilter
   quizAttempts: QuizAttemptListRelationFilter
   role: EnumRoleFilter
+  streak: UserStreakWhereInput
   updatedAt: DateTimeFilter
+  xp: UserXpWhereInput
+  xpEvents: XpEventListRelationFilter
+}
+
+type UserXp {
+  todayAsOf: DateTime!
+  todayXp: Int!
+  totalXp: Int!
+  user: User!
+  userId: ID!
+  weeklyXp: Json!
+}
+
+input UserXpAvgOrderByAggregateInput {
+  todayXp: SortOrder
+  totalXp: SortOrder
+}
+
+input UserXpCountOrderByAggregateInput {
+  todayAsOf: SortOrder
+  todayXp: SortOrder
+  totalXp: SortOrder
+  userId: SortOrder
+  weeklyXp: SortOrder
+}
+
+input UserXpCreateInput {
+  todayAsOf: DateTime
+  todayXp: Int
+  totalXp: Int
+  user: UserCreateNestedOneWithoutXpInput!
+  weeklyXp: Json
+}
+
+input UserXpCreateManyInput {
+  todayAsOf: DateTime
+  todayXp: Int
+  totalXp: Int
+  userId: String!
+  weeklyXp: Json
+}
+
+input UserXpCreateNestedOneWithoutUserInput {
+  connect: UserXpWhereUniqueInput
+  connectOrCreate: UserXpCreateOrConnectWithoutUserInput
+  create: UserXpCreateWithoutUserInput
+}
+
+input UserXpCreateOrConnectWithoutUserInput {
+  create: UserXpCreateWithoutUserInput!
+  where: UserXpWhereUniqueInput!
+}
+
+input UserXpCreateWithoutUserInput {
+  todayAsOf: DateTime
+  todayXp: Int
+  totalXp: Int
+  weeklyXp: Json
+}
+
+input UserXpMaxOrderByAggregateInput {
+  todayAsOf: SortOrder
+  todayXp: SortOrder
+  totalXp: SortOrder
+  userId: SortOrder
+}
+
+input UserXpMinOrderByAggregateInput {
+  todayAsOf: SortOrder
+  todayXp: SortOrder
+  totalXp: SortOrder
+  userId: SortOrder
+}
+
+input UserXpNullableScalarRelationFilter {
+  is: UserXpWhereInput
+  isNot: UserXpWhereInput
+}
+
+input UserXpOrderByWithAggregationInput {
+  _avg: UserXpAvgOrderByAggregateInput
+  _count: UserXpCountOrderByAggregateInput
+  _max: UserXpMaxOrderByAggregateInput
+  _min: UserXpMinOrderByAggregateInput
+  _sum: UserXpSumOrderByAggregateInput
+  todayAsOf: SortOrder
+  todayXp: SortOrder
+  totalXp: SortOrder
+  userId: SortOrder
+  weeklyXp: SortOrder
+}
+
+input UserXpOrderByWithRelationInput {
+  todayAsOf: SortOrder
+  todayXp: SortOrder
+  totalXp: SortOrder
+  user: UserOrderByWithRelationInput
+  userId: SortOrder
+  weeklyXp: SortOrder
+}
+
+enum UserXpScalarFieldEnum {
+  todayAsOf
+  todayXp
+  totalXp
+  userId
+  weeklyXp
+}
+
+input UserXpScalarWhereWithAggregatesInput {
+  AND: [UserXpScalarWhereWithAggregatesInput!]
+  NOT: [UserXpScalarWhereWithAggregatesInput!]
+  OR: [UserXpScalarWhereWithAggregatesInput!]
+  todayAsOf: DateTimeWithAggregatesFilter
+  todayXp: IntWithAggregatesFilter
+  totalXp: IntWithAggregatesFilter
+  userId: StringWithAggregatesFilter
+  weeklyXp: JsonWithAggregatesFilter
+}
+
+input UserXpSumOrderByAggregateInput {
+  todayXp: SortOrder
+  totalXp: SortOrder
+}
+
+input UserXpUpdateInput {
+  todayAsOf: DateTimeFieldUpdateOperationsInput
+  todayXp: IntFieldUpdateOperationsInput
+  totalXp: IntFieldUpdateOperationsInput
+  user: UserUpdateOneRequiredWithoutXpNestedInput
+  weeklyXp: Json
+}
+
+input UserXpUpdateManyMutationInput {
+  todayAsOf: DateTimeFieldUpdateOperationsInput
+  todayXp: IntFieldUpdateOperationsInput
+  totalXp: IntFieldUpdateOperationsInput
+  weeklyXp: Json
+}
+
+input UserXpUpdateOneWithoutUserNestedInput {
+  connect: UserXpWhereUniqueInput
+  connectOrCreate: UserXpCreateOrConnectWithoutUserInput
+  create: UserXpCreateWithoutUserInput
+  delete: UserXpWhereInput
+  disconnect: UserXpWhereInput
+  update: UserXpUpdateToOneWithWhereWithoutUserInput
+  upsert: UserXpUpsertWithoutUserInput
+}
+
+input UserXpUpdateToOneWithWhereWithoutUserInput {
+  data: UserXpUpdateWithoutUserInput!
+  where: UserXpWhereInput
+}
+
+input UserXpUpdateWithoutUserInput {
+  todayAsOf: DateTimeFieldUpdateOperationsInput
+  todayXp: IntFieldUpdateOperationsInput
+  totalXp: IntFieldUpdateOperationsInput
+  weeklyXp: Json
+}
+
+input UserXpUpsertWithoutUserInput {
+  create: UserXpCreateWithoutUserInput!
+  update: UserXpUpdateWithoutUserInput!
+  where: UserXpWhereInput
+}
+
+input UserXpWhereInput {
+  AND: [UserXpWhereInput!]
+  NOT: [UserXpWhereInput!]
+  OR: [UserXpWhereInput!]
+  todayAsOf: DateTimeFilter
+  todayXp: IntFilter
+  totalXp: IntFilter
+  user: UserWhereInput
+  userId: StringFilter
+  weeklyXp: JsonFilter
+}
+
+input UserXpWhereUniqueInput {
+  AND: [UserXpWhereInput!]
+  NOT: [UserXpWhereInput!]
+  OR: [UserXpWhereInput!]
+  todayAsOf: DateTimeFilter
+  todayXp: IntFilter
+  totalXp: IntFilter
+  user: UserWhereInput
+  userId: String
+  weeklyXp: JsonFilter
 }
 
 input UuidFilter {
@@ -5178,4 +5815,246 @@ input UuidWithAggregatesFilter {
   mode: QueryMode
   not: NestedUuidWithAggregatesFilter
   notIn: [String!]
+}
+
+type XpEvent {
+  amount: Int!
+  createdAt: DateTime!
+  id: ID!
+  metadata: Json
+  reason: String!
+  user: User!
+  userId: String!
+}
+
+input XpEventAvgOrderByAggregateInput {
+  amount: SortOrder
+}
+
+input XpEventCountOrderByAggregateInput {
+  amount: SortOrder
+  createdAt: SortOrder
+  id: SortOrder
+  metadata: SortOrder
+  reason: SortOrder
+  userId: SortOrder
+}
+
+input XpEventCreateInput {
+  amount: Int!
+  createdAt: DateTime
+  id: String
+  metadata: Json
+  reason: String!
+  user: UserCreateNestedOneWithoutXpEventsInput!
+}
+
+input XpEventCreateManyInput {
+  amount: Int!
+  createdAt: DateTime
+  id: String
+  metadata: Json
+  reason: String!
+  userId: String!
+}
+
+input XpEventCreateManyUserInput {
+  amount: Int!
+  createdAt: DateTime
+  id: String
+  metadata: Json
+  reason: String!
+}
+
+input XpEventCreateManyUserInputEnvelope {
+  data: [XpEventCreateManyUserInput!]!
+  skipDuplicates: Boolean
+}
+
+input XpEventCreateNestedManyWithoutUserInput {
+  connect: [XpEventWhereUniqueInput!]
+  connectOrCreate: [XpEventCreateOrConnectWithoutUserInput!]
+  create: [XpEventCreateWithoutUserInput!]
+  createMany: XpEventCreateManyUserInputEnvelope
+}
+
+input XpEventCreateOrConnectWithoutUserInput {
+  create: XpEventCreateWithoutUserInput!
+  where: XpEventWhereUniqueInput!
+}
+
+input XpEventCreateWithoutUserInput {
+  amount: Int!
+  createdAt: DateTime
+  id: String
+  metadata: Json
+  reason: String!
+}
+
+input XpEventListRelationFilter {
+  every: XpEventWhereInput
+  none: XpEventWhereInput
+  some: XpEventWhereInput
+}
+
+input XpEventMaxOrderByAggregateInput {
+  amount: SortOrder
+  createdAt: SortOrder
+  id: SortOrder
+  reason: SortOrder
+  userId: SortOrder
+}
+
+input XpEventMinOrderByAggregateInput {
+  amount: SortOrder
+  createdAt: SortOrder
+  id: SortOrder
+  reason: SortOrder
+  userId: SortOrder
+}
+
+input XpEventOrderByRelationAggregateInput {
+  _count: SortOrder
+}
+
+input XpEventOrderByWithAggregationInput {
+  _avg: XpEventAvgOrderByAggregateInput
+  _count: XpEventCountOrderByAggregateInput
+  _max: XpEventMaxOrderByAggregateInput
+  _min: XpEventMinOrderByAggregateInput
+  _sum: XpEventSumOrderByAggregateInput
+  amount: SortOrder
+  createdAt: SortOrder
+  id: SortOrder
+  metadata: SortOrder
+  reason: SortOrder
+  userId: SortOrder
+}
+
+input XpEventOrderByWithRelationInput {
+  amount: SortOrder
+  createdAt: SortOrder
+  id: SortOrder
+  metadata: SortOrder
+  reason: SortOrder
+  user: UserOrderByWithRelationInput
+  userId: SortOrder
+}
+
+enum XpEventScalarFieldEnum {
+  amount
+  createdAt
+  id
+  metadata
+  reason
+  userId
+}
+
+input XpEventScalarWhereInput {
+  AND: [XpEventScalarWhereInput!]
+  NOT: [XpEventScalarWhereInput!]
+  OR: [XpEventScalarWhereInput!]
+  amount: IntFilter
+  createdAt: DateTimeFilter
+  id: UuidFilter
+  metadata: JsonNullableFilter
+  reason: StringFilter
+  userId: StringFilter
+}
+
+input XpEventScalarWhereWithAggregatesInput {
+  AND: [XpEventScalarWhereWithAggregatesInput!]
+  NOT: [XpEventScalarWhereWithAggregatesInput!]
+  OR: [XpEventScalarWhereWithAggregatesInput!]
+  amount: IntWithAggregatesFilter
+  createdAt: DateTimeWithAggregatesFilter
+  id: UuidWithAggregatesFilter
+  metadata: JsonNullableWithAggregatesFilter
+  reason: StringWithAggregatesFilter
+  userId: StringWithAggregatesFilter
+}
+
+input XpEventSumOrderByAggregateInput {
+  amount: SortOrder
+}
+
+input XpEventUpdateInput {
+  amount: IntFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  id: StringFieldUpdateOperationsInput
+  metadata: Json
+  reason: StringFieldUpdateOperationsInput
+  user: UserUpdateOneRequiredWithoutXpEventsNestedInput
+}
+
+input XpEventUpdateManyMutationInput {
+  amount: IntFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  id: StringFieldUpdateOperationsInput
+  metadata: Json
+  reason: StringFieldUpdateOperationsInput
+}
+
+input XpEventUpdateManyWithWhereWithoutUserInput {
+  data: XpEventUpdateManyMutationInput!
+  where: XpEventScalarWhereInput!
+}
+
+input XpEventUpdateManyWithoutUserNestedInput {
+  connect: [XpEventWhereUniqueInput!]
+  connectOrCreate: [XpEventCreateOrConnectWithoutUserInput!]
+  create: [XpEventCreateWithoutUserInput!]
+  createMany: XpEventCreateManyUserInputEnvelope
+  delete: [XpEventWhereUniqueInput!]
+  deleteMany: [XpEventScalarWhereInput!]
+  disconnect: [XpEventWhereUniqueInput!]
+  set: [XpEventWhereUniqueInput!]
+  update: [XpEventUpdateWithWhereUniqueWithoutUserInput!]
+  updateMany: [XpEventUpdateManyWithWhereWithoutUserInput!]
+  upsert: [XpEventUpsertWithWhereUniqueWithoutUserInput!]
+}
+
+input XpEventUpdateWithWhereUniqueWithoutUserInput {
+  data: XpEventUpdateWithoutUserInput!
+  where: XpEventWhereUniqueInput!
+}
+
+input XpEventUpdateWithoutUserInput {
+  amount: IntFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  id: StringFieldUpdateOperationsInput
+  metadata: Json
+  reason: StringFieldUpdateOperationsInput
+}
+
+input XpEventUpsertWithWhereUniqueWithoutUserInput {
+  create: XpEventCreateWithoutUserInput!
+  update: XpEventUpdateWithoutUserInput!
+  where: XpEventWhereUniqueInput!
+}
+
+input XpEventWhereInput {
+  AND: [XpEventWhereInput!]
+  NOT: [XpEventWhereInput!]
+  OR: [XpEventWhereInput!]
+  amount: IntFilter
+  createdAt: DateTimeFilter
+  id: UuidFilter
+  metadata: JsonNullableFilter
+  reason: StringFilter
+  user: UserWhereInput
+  userId: StringFilter
+}
+
+input XpEventWhereUniqueInput {
+  AND: [XpEventWhereInput!]
+  NOT: [XpEventWhereInput!]
+  OR: [XpEventWhereInput!]
+  amount: IntFilter
+  createdAt: DateTimeFilter
+  id: String
+  metadata: JsonNullableFilter
+  reason: StringFilter
+  user: UserWhereInput
+  userId: StringFilter
 }

--- a/apps/client-frontend/src/app.tsx
+++ b/apps/client-frontend/src/app.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 
 import ProtectedRoute from "./components/ProtectedRoute";
+import { AuthProvider } from "./contexts/AuthContext";
 // ErrorBoundary lives inside ProtectedMainLayout because React Router's default
 // ErrorBoundary would otherwise replace it.
 import ErrorBoundary from "./components/ErrorBoundary";
@@ -12,7 +13,9 @@ import LessonsPage from "./pages/LessonsPage";
 import SkillTreesPage from "./pages/SkillTreesPage";
 import ProfilePage from "./pages/ProfilePage";
 import CourseDetailPage from "./pages/CourseDetailPage";
+import NodePage from "./pages/NodePage";
 import CatalogPage from "./pages/CatalogPage";
+import LoginPage from "./pages/LoginPage";
 import NotFoundPage from "./pages/NotFoundPage";
 
 // Shared shell for all authenticated routes.
@@ -28,6 +31,10 @@ function ProtectedMainLayout() {
 
 const router = createBrowserRouter([
   {
+    path: "/login",
+    element: <LoginPage />,
+  },
+  {
     path: "/",
     element: <ProtectedMainLayout />,
     children: [
@@ -37,6 +44,7 @@ const router = createBrowserRouter([
       { path: "skill-trees", element: <SkillTreesPage /> },
       { path: "profile", element: <ProfilePage /> },
       { path: "courses/:courseId", element: <CourseDetailPage /> },
+      { path: "courses/:courseId/nodes/:nodeId", element: <NodePage /> },
       { path: "catalog", element: <CatalogPage /> },
     ],
   },
@@ -47,5 +55,9 @@ const router = createBrowserRouter([
 ]);
 
 export default function App() {
-  return <RouterProvider router={router} />;
+  return (
+    <AuthProvider>
+      <RouterProvider router={router} />
+    </AuthProvider>
+  );
 }

--- a/apps/client-frontend/src/components/LessonViewer.tsx
+++ b/apps/client-frontend/src/components/LessonViewer.tsx
@@ -1,22 +1,9 @@
 import React, { useEffect } from "react";
 import DOMPurify from "dompurify";
 import ReactPlayer from "react-player";
-import { useQuery, useMutation } from "@apollo/client/react";
-import { ContentType } from "@synth-tree/api-types";
-import { LESSON_BLOCKS_QUERY } from "../graphql/queries/lessonBlocks";
+import { useMutation } from "@apollo/client/react";
+import { useLessonBlocksByNodeQuery } from "@synth-tree/api-types";
 import { START_NODE_PROGRESS } from "../graphql/mutations/startNodeProgress";
-
-interface LessonBlock {
-  id: string;
-  type: ContentType;
-  content: string;
-  caption?: string | null;
-  order: number;
-}
-
-interface LessonBlocksData {
-  lessonBlocks: LessonBlock[];
-}
 
 interface LessonViewerProps {
   nodeId: string;
@@ -24,7 +11,7 @@ interface LessonViewerProps {
 }
 
 export const LessonViewer: React.FC<LessonViewerProps> = ({ nodeId, onNext }) => {
-  const { data, loading, error } = useQuery<LessonBlocksData>(LESSON_BLOCKS_QUERY, {
+  const { data, loading, error } = useLessonBlocksByNodeQuery({
     variables: { nodeId },
   });
 
@@ -40,28 +27,27 @@ export const LessonViewer: React.FC<LessonViewerProps> = ({ nodeId, onNext }) =>
 
   if (loading) return <div>Loading lesson...</div>;
   if (error) return <div>Error loading lesson.</div>;
-  if (!data) return <div>No lesson data found.</div>;
 
-  const blocks = [...data.lessonBlocks].sort((a, b) => a.order - b.order);
+  const blocks = [...(data?.lessonBlocksByNode ?? [])].sort(
+    (a, b) => a.order - b.order,
+  );
 
   const renderHTML = (html: string) => (
     <div
       className="leading-relaxed text-gray-800"
-      dangerouslySetInnerHTML={{
-        __html: DOMPurify.sanitize(html),
-      }}
+      dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(html) }}
     />
   );
 
-  const renderImage = (block: LessonBlock) => (
+  const renderImage = (url: string, caption?: string | null) => (
     <figure className="m-0 text-center">
       <img
-        src={block.content}
-        alt={block.caption || "Lesson image"}
+        src={url}
+        alt={caption || "Lesson image"}
         className="max-w-full h-auto rounded-lg shadow-md"
       />
-      {block.caption && (
-        <figcaption className="mt-3 text-sm text-gray-500 italic">{block.caption}</figcaption>
+      {caption && (
+        <figcaption className="mt-3 text-sm text-gray-500 italic">{caption}</figcaption>
       )}
     </figure>
   );
@@ -85,16 +71,16 @@ export const LessonViewer: React.FC<LessonViewerProps> = ({ nodeId, onNext }) =>
     </div>
   );
 
-  const renderBlock = (block: LessonBlock) => {
+  const renderBlock = (block: (typeof blocks)[number]) => {
     switch (block.type) {
-      case ContentType.Html:
-        return renderHTML(block.content);
-      case ContentType.Image:
-        return renderImage(block);
-      case ContentType.Video:
-        return renderVideo(block.content);
-      case ContentType.Embed:
-        return renderEmbed(block.content);
+      case "HTML":
+        return renderHTML(block.html ?? "");
+      case "IMAGE":
+        return renderImage(block.url ?? "", block.caption);
+      case "VIDEO":
+        return renderVideo(block.url ?? "");
+      case "EMBED":
+        return renderEmbed(block.url ?? "");
       default:
         return null;
     }

--- a/apps/client-frontend/src/components/ProtectedRoute.tsx
+++ b/apps/client-frontend/src/components/ProtectedRoute.tsx
@@ -1,14 +1,24 @@
-export default function ProtectedRoute({ children }: { children: any }) {
-  const isLoggedIn = true; // Change to false to test the protection
-  
-  if (!isLoggedIn) {
+import { Navigate } from "react-router-dom";
+import { useAuthContext } from "../contexts/AuthContext";
+
+export default function ProtectedRoute({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { loading, isAuthenticated } = useAuthContext();
+
+  if (loading) {
     return (
-      <div className="p-8">
-        <h1>Please Log In</h1>
-        <p>You need to be logged in to see this page.</p>
+      <div className="flex min-h-screen items-center justify-center text-gray-500">
+        Loading…
       </div>
     );
   }
 
-  return children;
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return <>{children}</>;
 }

--- a/apps/client-frontend/src/components/QuizRunner.tsx
+++ b/apps/client-frontend/src/components/QuizRunner.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import { useMutation } from "@apollo/client/react";
+import { SUBMIT_QUIZ_ATTEMPT } from "../graphql/mutations/submitQuizAttempt";
+
+type QuizOption = { id: string; text: string };
+type QuizQuestion = {
+  id: string;
+  prompt: string;
+  type: string; // SINGLE_CHOICE | MULTIPLE_CHOICE | OPEN_QUESTION
+  options: QuizOption[];
+};
+export type QuizForRunner = {
+  id: string;
+  title?: string | null;
+  required: boolean;
+  questions: QuizQuestion[];
+};
+
+type SubmitResult = { submitQuizAttempt: { id: string; passed: boolean } };
+
+export default function QuizRunner({ quiz }: { quiz: QuizForRunner }) {
+  const [choice, setChoice] = useState<Record<string, string[]>>({});
+  const [text, setText] = useState<Record<string, string>>({});
+  const [passed, setPassed] = useState<boolean | undefined>(undefined);
+
+  const [submit, { loading, error }] = useMutation<SubmitResult>(SUBMIT_QUIZ_ATTEMPT);
+
+  const toggle = (qId: string, optId: string, multiple: boolean) =>
+    setChoice((prev) => {
+      const cur = prev[qId] ?? [];
+      if (multiple) {
+        return {
+          ...prev,
+          [qId]: cur.includes(optId) ? cur.filter((x) => x !== optId) : [...cur, optId],
+        };
+      }
+      return { ...prev, [qId]: [optId] };
+    });
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const answers = quiz.questions.map((q) =>
+      JSON.stringify({
+        questionId: q.id,
+        answer:
+          q.type === "OPEN_QUESTION"
+            ? { text: text[q.id] ?? "" }
+            : { selectedOptionIds: choice[q.id] ?? [] },
+      }),
+    );
+    const res = await submit({ variables: { quizId: quiz.id, answers } });
+    setPassed(res.data?.submitQuizAttempt.passed ?? false);
+  };
+
+  return (
+    <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm">
+      <h2 className="mb-4 text-xl font-semibold text-gray-900">
+        {quiz.title ?? "Quiz"}
+        {quiz.required ? " · required" : ""}
+      </h2>
+
+      <form onSubmit={onSubmit} className="flex flex-col gap-6">
+        {quiz.questions.map((q, i) => (
+          <div key={q.id}>
+            <p className="mb-2 font-medium text-gray-800">
+              {i + 1}. {q.prompt}
+            </p>
+            {q.type === "OPEN_QUESTION" ? (
+              <textarea
+                value={text[q.id] ?? ""}
+                onChange={(e) => setText((p) => ({ ...p, [q.id]: e.target.value }))}
+                rows={3}
+                placeholder="Your answer…"
+                className="w-full rounded-lg border border-gray-300 p-2 text-sm focus:border-blue-500 focus:outline-none"
+              />
+            ) : (
+              <div className="flex flex-col gap-2">
+                {q.options.map((o) => {
+                  const multiple = q.type === "MULTIPLE_CHOICE";
+                  return (
+                    <label key={o.id} className="flex items-center gap-2 text-sm text-gray-700">
+                      <input
+                        type={multiple ? "checkbox" : "radio"}
+                        name={q.id}
+                        checked={(choice[q.id] ?? []).includes(o.id)}
+                        onChange={() => toggle(q.id, o.id, multiple)}
+                      />
+                      {o.text}
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        ))}
+
+        <div className="flex items-center gap-4">
+          <button
+            type="submit"
+            disabled={loading}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {loading ? "Submitting…" : "Submit quiz"}
+          </button>
+          {passed !== undefined && (
+            <span className={`text-sm font-medium ${passed ? "text-green-600" : "text-gray-600"}`}>
+              {passed ? "✓ Passed!" : "Submitted — not passed yet"}
+            </span>
+          )}
+          {error && <span className="text-sm text-red-600">Could not submit.</span>}
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/apps/client-frontend/src/contexts/AuthContext.tsx
+++ b/apps/client-frontend/src/contexts/AuthContext.tsx
@@ -1,0 +1,58 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+import {
+  onAuthStateChanged,
+  signInWithEmailAndPassword,
+  signOut,
+  type User as FirebaseUser,
+  type UserCredential,
+} from "firebase/auth";
+import { auth } from "../lib/firebase";
+
+interface AuthContextType {
+  /** Current Firebase user, or null when signed out. */
+  user: FirebaseUser | null;
+  /** True until the initial auth state has been resolved. */
+  loading: boolean;
+  /** Convenience flag: a user is signed in. */
+  isAuthenticated: boolean;
+  /** Sign in with email + password. */
+  login: (email: string, password: string) => Promise<UserCredential>;
+  /** Sign out the current user. */
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<FirebaseUser | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (u) => {
+      setUser(u);
+      setLoading(false);
+    });
+    return () => unsubscribe();
+  }, []);
+
+  const login = (email: string, password: string) =>
+    signInWithEmailAndPassword(auth, email, password);
+
+  const logout = () => signOut(auth);
+
+  return (
+    <AuthContext.Provider
+      value={{ user, loading, isAuthenticated: !!user, login, logout }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuthContext(): AuthContextType {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error("useAuthContext must be used within an AuthProvider");
+  }
+  return ctx;
+}

--- a/apps/client-frontend/src/graphql/mutations/submitQuizAttempt.ts
+++ b/apps/client-frontend/src/graphql/mutations/submitQuizAttempt.ts
@@ -1,0 +1,14 @@
+import { gql } from "@apollo/client";
+
+// answers: a list of JSON strings, one per question, each of the shape
+//   { "questionId": "...", "answer": { "selectedOptionIds": ["..."] } }   // choice
+//   { "questionId": "...", "answer": { "text": "..." } }                  // open
+// The server creates the attempt and grades it (see gradeQuizAttempt / SYN-54).
+export const SUBMIT_QUIZ_ATTEMPT = gql`
+  mutation SubmitQuizAttempt($quizId: ID!, $answers: [String!]!) {
+    submitQuizAttempt(quizId: $quizId, answers: $answers) {
+      id
+      passed
+    }
+  }
+`;

--- a/apps/client-frontend/src/graphql/queries/publicCourse.ts
+++ b/apps/client-frontend/src/graphql/queries/publicCourse.ts
@@ -10,7 +10,28 @@ export const PUBLIC_COURSE_QUERY = gql`
       trees {
         id
         title
-        description }
+        description
+        nodes {
+          id
+          title
+          step
+          orderInStep
+          quiz {
+            id
+            title
+            required
+            questions {
+              id
+              prompt
+              type
+              options {
+                id
+                text
+              }
+            }
+          }
+        }
+      }
     }
   }
 `;

--- a/apps/client-frontend/src/hooks/useAuth.ts
+++ b/apps/client-frontend/src/hooks/useAuth.ts
@@ -1,13 +1,10 @@
-import { getAuth, signOut } from "firebase/auth";
+import { useAuthContext } from "../contexts/AuthContext";
 
+/**
+ * Thin wrapper over the auth context so existing callers (e.g. ProfilePage's
+ * `const { logout } = useAuth()`) keep working, while new code can also read
+ * `user` / `login` / `loading` / `isAuthenticated`.
+ */
 export default function useAuth() {
-  const logout = async () => {
-    const auth = getAuth();
-    await signOut(auth);
-    // TODO: redirect to /auth/login once client-frontend auth is implemented
-    // For now reload the page — ProtectedRoute will handle blocking unauthenticated users
-    window.location.href = "/";
-  };
-
-  return { logout };
+  return useAuthContext();
 }

--- a/apps/client-frontend/src/pages/CourseDetailPage.tsx
+++ b/apps/client-frontend/src/pages/CourseDetailPage.tsx
@@ -1,48 +1,66 @@
-// CourseDetailPage - shows the full details of a single course
-// This page loads when a user clicks a course card
-// The courseId comes from the URL e.g. /courses/123
-
-import { useParams } from "react-router-dom";
-
-// Shape of what a course looks like - matches the mock data in SkillTreeHomePage
-interface Course {
-  id: string;
-  title: string;
-  description: string;
-}
-
-// MOCK DATA - placeholder only, replace when real database courses are available
-const mockCourses: Course[] = [
-  { id: "1", title: "Organic Chemistry", description: "Learn the basics of organic chemistry" },
-  { id: "2", title: "Basics of Physics", description: "Introduction to physics concepts" },
-  { id: "3", title: "Advanced Geometry", description: "Deep dive into geometric principles" },
-];
+// CourseDetailPage — shows a single course and its skill-tree nodes.
+// Loads when a learner clicks a course card. courseId comes from the URL.
+import { Link, useParams } from "react-router-dom";
+import { usePublicCourseQuery } from "@synth-tree/api-types";
 
 export default function CourseDetailPage() {
-  // Grab the courseId from the URL
   const { courseId } = useParams();
+  const { data, loading, error } = usePublicCourseQuery({
+    variables: { id: courseId ?? "" },
+    skip: !courseId,
+  });
 
-  // Find the course that matches the ID in the URL
-  const course = mockCourses.find((c) => c.id === courseId);
+  if (loading) return <div className="p-8">Loading…</div>;
+  if (error) return <div className="p-8">Error: {error.message}</div>;
 
-  // If no course found show a simple message
+  const course = data?.publicCourse;
   if (!course) return <div className="p-8">Course not found.</div>;
 
   return (
-    <div className="flex flex-col gap-6 p-8 max-w-3xl mx-auto">
-      {/* Back link to go back to the course list */}
-      <a href="/" className="text-sm text-gray-500 hover:underline">← Back to courses</a>
+    <div className="mx-auto flex max-w-3xl flex-col gap-6 p-8">
+      <Link to="/" className="text-sm text-gray-500 hover:underline">
+        ← Back to courses
+      </Link>
 
-      {/* Course title */}
-      <h1 className="text-3xl font-bold text-gray-900">{course.title}</h1>
+      <div>
+        <h1 className="text-3xl font-bold text-gray-900">{course.title}</h1>
+        {course.description && (
+          <p className="mt-2 text-lg text-gray-600">{course.description}</p>
+        )}
+      </div>
 
-      {/* Course description */}
-      <p className="text-gray-600 text-lg">{course.description}</p>
-
-      {/* Start learning button */}
-      <button className="w-fit bg-black text-white px-6 py-3 rounded-xl hover:bg-gray-800 transition-colors">
-        Start Learning
-      </button>
+      {course.trees.map((tree) => {
+        const nodes = [...tree.nodes].sort(
+          (a, b) => a.step - b.step || a.orderInStep - b.orderInStep,
+        );
+        return (
+          <section key={tree.id} className="flex flex-col gap-3">
+            <h2 className="text-xl font-semibold text-gray-900">{tree.title}</h2>
+            {tree.description && (
+              <p className="text-sm text-gray-500">{tree.description}</p>
+            )}
+            <ol className="flex flex-col gap-2">
+              {nodes.map((node, i) => (
+                <li key={node.id}>
+                  <Link
+                    to={`/courses/${course.id}/nodes/${node.id}`}
+                    className="flex items-center justify-between rounded-xl border border-gray-200 bg-white px-4 py-3 transition-shadow hover:shadow-md"
+                  >
+                    <span className="font-medium text-gray-900">
+                      {i + 1}. {node.title}
+                    </span>
+                    {node.quiz && (
+                      <span className="rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700">
+                        Quiz
+                      </span>
+                    )}
+                  </Link>
+                </li>
+              ))}
+            </ol>
+          </section>
+        );
+      })}
     </div>
   );
 }

--- a/apps/client-frontend/src/pages/LoginPage.tsx
+++ b/apps/client-frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import { Navigate, useNavigate } from "react-router-dom";
+import { useAuthContext } from "../contexts/AuthContext";
+
+export default function LoginPage() {
+  const { login, isAuthenticated } = useAuthContext();
+  const navigate = useNavigate();
+  // Prefilled for local/demo convenience (see db:seed:local-users).
+  const [email, setEmail] = useState("learner@local.dev");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  if (isAuthenticated) return <Navigate to="/" replace />;
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      await login(email, password);
+      navigate("/", { replace: true });
+    } catch (err) {
+      console.error(err);
+      setError("Sign-in failed. Check your email and password.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4">
+      <form
+        onSubmit={onSubmit}
+        className="w-full max-w-sm rounded-3xl border border-gray-200 bg-white p-8 shadow-sm"
+      >
+        <h1 className="mb-1 text-2xl font-semibold text-gray-900">Welcome back</h1>
+        <p className="mb-6 text-sm text-gray-500">Sign in to continue learning.</p>
+
+        <label className="mb-1 block text-sm font-medium text-gray-700">Email</label>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          autoComplete="email"
+          required
+          className="mb-4 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+        />
+
+        <label className="mb-1 block text-sm font-medium text-gray-700">Password</label>
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          autoComplete="current-password"
+          required
+          className="mb-4 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+        />
+
+        {error && <p className="mb-4 text-sm text-red-600">{error}</p>}
+
+        <button
+          type="submit"
+          disabled={submitting}
+          className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {submitting ? "Signing in…" : "Sign in"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/apps/client-frontend/src/pages/NodePage.tsx
+++ b/apps/client-frontend/src/pages/NodePage.tsx
@@ -1,0 +1,41 @@
+// NodePage — a single skill node: its lesson content + (optional) quiz.
+// Route: /courses/:courseId/nodes/:nodeId
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { usePublicCourseQuery } from "@synth-tree/api-types";
+import { LessonViewer } from "../components/LessonViewer";
+import QuizRunner from "../components/QuizRunner";
+
+export default function NodePage() {
+  const { courseId, nodeId } = useParams();
+  const navigate = useNavigate();
+
+  const { data, loading, error } = usePublicCourseQuery({
+    variables: { id: courseId ?? "" },
+    skip: !courseId,
+  });
+
+  if (loading) return <div className="p-8">Loading…</div>;
+  if (error) return <div className="p-8">Error: {error.message}</div>;
+
+  const course = data?.publicCourse;
+  const node = course?.trees.flatMap((t) => t.nodes).find((n) => n.id === nodeId);
+  if (!course || !node) return <div className="p-8">Lesson not found.</div>;
+
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-8 p-8">
+      <Link
+        to={`/courses/${course.id}`}
+        className="text-sm text-gray-500 hover:underline"
+      >
+        ← Back to {course.title}
+      </Link>
+
+      <h1 className="text-2xl font-bold text-gray-900">{node.title}</h1>
+
+      {/* Lesson content. Opening this marks the node in progress (SYN-31). */}
+      <LessonViewer nodeId={node.id} onNext={() => navigate(`/courses/${course.id}`)} />
+
+      {node.quiz && <QuizRunner quiz={node.quiz} />}
+    </div>
+  );
+}

--- a/docs/demo/cohort-demo-script.md
+++ b/docs/demo/cohort-demo-script.md
@@ -1,0 +1,189 @@
+# Synth Tree — Cohort Demo Script
+
+A click-through script for the stakeholder demo. Designed for **one presenter**
+sharing their screen, moving through **four surfaces in order** to minimize
+switching: HTML mocks → Admin dashboard → Learner app → Storybook.
+
+Target length: ~20–25 min.
+
+> **Dependency note.** Segments 1, 2, and 4 work on `main` today. Segment 3
+> (the learner deep-flow: login, course detail, lessons, quiz) depends on the
+> **demo-enablement PR** (learner Firebase login, course-detail wired to the
+> API, a lesson/quiz view, and the `db:seed:demo` script). A "works-today
+> fallback" for Segment 3 is at the end if that PR hasn't merged yet.
+
+---
+
+## 0. Pre-flight checklist (do this before the call, then dry-run once)
+
+```bash
+git checkout main && git pull
+pnpm install
+pnpm db:start            # Postgres in Docker
+pnpm db:migrate:dev      # apply migrations
+pnpm db:seed:local-users # admin@local.dev + learner@local.dev (password: Local123!)
+pnpm db:seed:demo        # demo courses/trees/lessons/quizzes + learner progress
+pnpm dev                 # API :4000, admin :5173, client :5174
+pnpm storybook           # :6006 (separate terminal)
+```
+
+Then in the browser, set up **four tabs** and sign in ahead of time so nothing
+stalls live:
+
+1. `docs/design/desktop-mocks.html` (open the file directly) — and have
+   `mobile-mocks.html` ready.
+2. `http://localhost:5173` — **admin**, logged in as `admin@local.dev`.
+3. `http://localhost:5174` — **learner**, logged in as `learner@local.dev`.
+4. `http://localhost:6006` — **Storybook**.
+
+Start in **light mode**. Keep the GraphQL playground (`:4000`) closed unless a
+technical stakeholder asks to see the API.
+
+---
+
+## 1. What this cohort shipped (feature → PR map)
+
+Use this to credit the work; you don't need to read it aloud.
+
+| Area | Feature | PR · author |
+|---|---|---|
+| Admin | Courses page wired to GraphQL + status badges | #74 · Gabriela |
+| Admin | Grid/list view toggle | #76 · Seyonce |
+| Admin | Publish / unpublish course + toast | #65 · Christian |
+| Admin | Soft-delete with confirm dialog | #77 · Seydou |
+| Admin | Dark mode + density selector | #70 · Ken |
+| Admin | Course Builder shell route | #67 · Christian |
+| Admin | Forgot-password flow | #72 · Adam |
+| Learner | Recommended-next carousel | #79 · Christian |
+| Learner | Catalog page + CourseCard | #71 · Walker |
+| Learner | Mobile bottom tab bar | #78 · Christian |
+| Learner | Start node progress on lesson open | #80 · Angel |
+| Design system | Hex node icons (status states) | #66 · Adam |
+| Design system | Shared Icon library | #69 · Adam |
+| Design system | Progress component | #67 · Christian |
+| Design system | HSL theme tokens | #64 · Ken |
+| API | Open-question quiz grading | #81 · Seyonce |
+| API | XP / streak persistence models | #75 · Rduffard |
+
+---
+
+## 2. Segment 1 — The vision: HTML mocks (~3 min) · Tab 1
+
+> *"Before the live app, here's the design direction the team is building
+> toward — you haven't seen these yet."*
+
+1. Open `desktop-mocks.html`. Walk the key screens (course catalog, course
+   detail, the skill-tree, a lesson). Keep it high-level — this is the "north star."
+2. Switch to `mobile-mocks.html`. *"The product is designed mobile-first too."*
+
+Transition: *"Now let's see how much of this is already real."*
+
+---
+
+## 3. Segment 2 — Admin dashboard (~8 min) · Tab 2 · `:5173`
+
+This is the most complete surface — a full course-authoring lifecycle.
+
+1. **Login page → dark mode.** Click the moon/sun icon to toggle dark mode
+   (persists). Toggle back. *"Theming is centralized — one toggle re-themes the
+   whole app."* (#64/#70)
+2. **Log in** as `admin@local.dev` → lands on **Courses**.
+3. **Courses list.** Point out **status badges** (Published/Draft), and each
+   card's "by <author> · edited <time> ago". (#74)
+4. **Grid ↔ List** toggle (top-right of the list). (#76)
+5. **Filter pills** — click **Published**, then **Draft**, then **All**. (#74)
+6. **Create a course.** Click **Create Course** → title "Cellular Respiration",
+   a short description → **Create**. It appears instantly. (#74)
+7. **Publish it.** ⋯ menu → **Publish course** → green toast; badge flips to
+   Published. (#65)
+8. **Density.** In the header, open the density control → switch
+   **compact / comfy** to show spacing respond live. (#70)
+9. **Soft delete.** ⋯ menu on the course you just made → **Delete** → the
+   **styled confirm dialog** appears → confirm. *"Deletes are soft — recoverable,
+   not destructive."* (#77)
+10. **Course Builder.** Click a course (or ⋯ → Edit) → the **Course Builder**
+    shell (Meta / Tree Canvas / Inspector). *"This is the authoring surface in
+    progress — the layout's in place, editing lands next."* (#67)
+
+Nothing here is a dead-end; move confidently.
+
+Transition: *"That's the instructor side. Now the learner experience."*
+
+---
+
+## 4. Segment 3 — Learner app (~8 min) · Tab 3 · `:5174`
+
+> Requires the **demo-enablement PR**. Fallback at the end if not merged.
+
+1. **Log in** as `learner@local.dev` (do this pre-call). 
+2. **Home.** Top is the **Recommended next** carousel — because we seeded
+   progress, it shows the learner's next nodes. Below: the published course grid,
+   then a **Browse catalog** card. (#79/#71)
+3. **Browse catalog** → the catalog grid of all published courses. (#71)
+4. **Open a course.** Click **Organic Chemistry** → the course detail page shows
+   the course and its **skill-tree nodes** (Atoms & Bonding → Functional Groups →
+   Isomerism → Your First Reaction), pulled live from the API.
+5. **Open a lesson.** Click **Atoms & Bonding** → the lesson renders (formatted
+   text + an embedded video). *"Opening a lesson automatically marks it in
+   progress."* (#80 fires `startNodeProgress` here.)
+6. **Take the quiz.** Scroll to the quiz → answer the questions → **Submit** →
+   the server grades it and shows **Passed**. *"Grading runs on the API,
+   including open-response handling."* (#81)
+7. **Back to Home** → the **Recommended next** carousel has updated now that this
+   node is complete. *"Recommendations react to real progress."* (#79/#80)
+8. **Mobile.** Open DevTools device toolbar (Cmd+Shift+M) → the **bottom tab
+   bar** (Home / Catalog / Profile) appears. Tap between tabs. (#78)
+9. **Profile** → show the learner profile (name/photo edit).
+
+Transition: *"All of that sits on a shared design system the team built."*
+
+---
+
+## 5. Segment 4 — Design system: Storybook (~3 min) · Tab 4 · `:6006`
+
+> *"These are the reusable building blocks behind both apps."*
+
+- **Hex** — the skill-node icon with status states
+  (locked / unlocked / current / completed). (#66)
+- **Icon** — the shared subject-icon library. (#69)
+- **Progress** — the progress bar component. (#67)
+- **Color Picker / theme tokens** — the theming foundation. (#64)
+
+---
+
+## 6. Closing (~1 min)
+
+> *"In three weeks the cohort delivered a working course-authoring dashboard, a
+> learner experience from catalog through lessons and graded quizzes, a shared
+> design system, and the data model for XP and streaks that powers what's next."*
+
+Optional, for a technical stakeholder: open the GraphQL playground (`:4000`) and
+run a query to show the API depth (e.g. `publicGetAllCourses`, or a
+`courseProgress` aggregate).
+
+---
+
+## 7. Avoid-list (don't click these live)
+
+- **Admin** → the avatar dropdown **Profile** link if it isn't wired (confirm at
+  dry-run).
+- **Learner** → the **Dashboard / Lessons / Skill Trees** top-nav items — they're
+  placeholder stubs.
+- Any course detail for an **unseeded** id.
+
+---
+
+## 8. Works-today fallback (if the demo-enablement PR isn't merged)
+
+Without it, the learner app has **no login** and lessons/quiz/progress/carousel
+are auth-gated (they'll error or show empty). For Segment 3, instead:
+
+1. **Home** — show the course grid + **Browse catalog** card (these are public
+   and work). The carousel will show its "all caught up" empty state.
+2. **Catalog** — the published-courses grid (public). 
+3. **Profile** + **mobile bottom tab bar** — both work.
+4. **Do not** click into a course card (the detail page is mock data) or the
+   lessons/quiz flow.
+5. Cover lessons, quiz grading (#81), progress (#80), and recommendations (#79)
+   by **narrating** them and showing them in the **GraphQL playground** +
+   **Storybook**.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "db:migrate:dev": "pnpm --filter @synth-tree/api run prisma:migrate:dev",
     "db:studio": "pnpm --filter @synth-tree/api run prisma:studio",
     "db:seed:local-users": "pnpm --filter @synth-tree/api db:seed:local-users",
+    "db:seed:demo": "pnpm --filter @synth-tree/api db:seed:demo",
     "create:user": "pnpm --filter @synth-tree/api create:user --",
     "refresh:token": "pnpm --filter @synth-tree/api refresh:token --",
     "dev": "pnpm db:start && pnpm --filter @synth-tree/theme build && pnpm --filter @synth-tree/ui build && pnpm --parallel --filter @synth-tree/admin-dashboard --filter @synth-tree/client-frontend --filter @synth-tree/api dev",

--- a/packages/api-types/src/graphql.ts
+++ b/packages/api-types/src/graphql.ts
@@ -692,9 +692,29 @@ export type IntWithAggregatesFilter = {
   notIn?: InputMaybe<Array<Scalars['Int']['input']>>;
 };
 
+export type JsonFilter = {
+  array_contains?: InputMaybe<Scalars['Json']['input']>;
+  array_ends_with?: InputMaybe<Scalars['Json']['input']>;
+  array_starts_with?: InputMaybe<Scalars['Json']['input']>;
+  equals?: InputMaybe<Scalars['Json']['input']>;
+  gt?: InputMaybe<Scalars['Json']['input']>;
+  gte?: InputMaybe<Scalars['Json']['input']>;
+  lt?: InputMaybe<Scalars['Json']['input']>;
+  lte?: InputMaybe<Scalars['Json']['input']>;
+  mode?: InputMaybe<QueryMode>;
+  not?: InputMaybe<Scalars['Json']['input']>;
+  path?: InputMaybe<Array<Scalars['String']['input']>>;
+  string_contains?: InputMaybe<Scalars['String']['input']>;
+  string_ends_with?: InputMaybe<Scalars['String']['input']>;
+  string_starts_with?: InputMaybe<Scalars['String']['input']>;
+};
+
 export type JsonNullValueFilter =
   | 'AnyNull'
   | 'DbNull'
+  | 'JsonNull';
+
+export type JsonNullValueInput =
   | 'JsonNull';
 
 export type JsonNullableFilter = {
@@ -718,6 +738,26 @@ export type JsonNullableWithAggregatesFilter = {
   _count?: InputMaybe<NestedIntNullableFilter>;
   _max?: InputMaybe<NestedJsonNullableFilter>;
   _min?: InputMaybe<NestedJsonNullableFilter>;
+  array_contains?: InputMaybe<Scalars['Json']['input']>;
+  array_ends_with?: InputMaybe<Scalars['Json']['input']>;
+  array_starts_with?: InputMaybe<Scalars['Json']['input']>;
+  equals?: InputMaybe<Scalars['Json']['input']>;
+  gt?: InputMaybe<Scalars['Json']['input']>;
+  gte?: InputMaybe<Scalars['Json']['input']>;
+  lt?: InputMaybe<Scalars['Json']['input']>;
+  lte?: InputMaybe<Scalars['Json']['input']>;
+  mode?: InputMaybe<QueryMode>;
+  not?: InputMaybe<Scalars['Json']['input']>;
+  path?: InputMaybe<Array<Scalars['String']['input']>>;
+  string_contains?: InputMaybe<Scalars['String']['input']>;
+  string_ends_with?: InputMaybe<Scalars['String']['input']>;
+  string_starts_with?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type JsonWithAggregatesFilter = {
+  _count?: InputMaybe<NestedIntFilter>;
+  _max?: InputMaybe<NestedJsonFilter>;
+  _min?: InputMaybe<NestedJsonFilter>;
   array_contains?: InputMaybe<Scalars['Json']['input']>;
   array_ends_with?: InputMaybe<Scalars['Json']['input']>;
   array_starts_with?: InputMaybe<Scalars['Json']['input']>;
@@ -1111,6 +1151,7 @@ export type Mutation = {
   publishCourse?: Maybe<Course>;
   publishLessonBlock?: Maybe<LessonBlocks>;
   setUserRole?: Maybe<User>;
+  startNodeProgress?: Maybe<UserNodeProgress>;
   submitQuizAttempt?: Maybe<QuizAttempt>;
   syncCurrentUser?: Maybe<User>;
   unpublishCourse?: Maybe<Course>;
@@ -1234,6 +1275,11 @@ export type MutationPublishLessonBlockArgs = {
 export type MutationSetUserRoleArgs = {
   role: Role;
   userId: Scalars['ID']['input'];
+};
+
+
+export type MutationStartNodeProgressArgs = {
+  nodeId: Scalars['ID']['input'];
 };
 
 
@@ -1549,6 +1595,23 @@ export type NestedIntWithAggregatesFilter = {
   lte?: InputMaybe<Scalars['Int']['input']>;
   not?: InputMaybe<NestedIntWithAggregatesFilter>;
   notIn?: InputMaybe<Array<Scalars['Int']['input']>>;
+};
+
+export type NestedJsonFilter = {
+  array_contains?: InputMaybe<Scalars['Json']['input']>;
+  array_ends_with?: InputMaybe<Scalars['Json']['input']>;
+  array_starts_with?: InputMaybe<Scalars['Json']['input']>;
+  equals?: InputMaybe<Scalars['Json']['input']>;
+  gt?: InputMaybe<Scalars['Json']['input']>;
+  gte?: InputMaybe<Scalars['Json']['input']>;
+  lt?: InputMaybe<Scalars['Json']['input']>;
+  lte?: InputMaybe<Scalars['Json']['input']>;
+  mode?: InputMaybe<QueryMode>;
+  not?: InputMaybe<Scalars['Json']['input']>;
+  path?: InputMaybe<Array<Scalars['String']['input']>>;
+  string_contains?: InputMaybe<Scalars['String']['input']>;
+  string_ends_with?: InputMaybe<Scalars['String']['input']>;
+  string_starts_with?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type NestedJsonNullableFilter = {
@@ -4945,7 +5008,10 @@ export type User = {
   quizAttempts: Array<QuizAttempt>;
   recommendedNext?: Maybe<Array<SkillNode>>;
   role: Role;
+  streak?: Maybe<UserStreak>;
   updatedAt: Scalars['DateTime']['output'];
+  xp?: Maybe<UserXp>;
+  xpEvents: Array<XpEvent>;
 };
 
 
@@ -4983,6 +5049,16 @@ export type UserRecommendedNextArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
+export type UserXpEventsArgs = {
+  cursor?: InputMaybe<XpEventWhereUniqueInput>;
+  distinct?: InputMaybe<Array<XpEventScalarFieldEnum>>;
+  orderBy?: InputMaybe<Array<XpEventOrderByWithRelationInput>>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<XpEventWhereInput>;
+};
+
 export type UserCountOrderByAggregateInput = {
   createdAt?: InputMaybe<SortOrder>;
   email?: InputMaybe<SortOrder>;
@@ -5003,7 +5079,10 @@ export type UserCreateInput = {
   photoUrl?: InputMaybe<Scalars['String']['input']>;
   quizAttempts?: InputMaybe<QuizAttemptCreateNestedManyWithoutUserInput>;
   role?: InputMaybe<Role>;
+  streak?: InputMaybe<UserStreakCreateNestedOneWithoutUserInput>;
   updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  xp?: InputMaybe<UserXpCreateNestedOneWithoutUserInput>;
+  xpEvents?: InputMaybe<XpEventCreateNestedManyWithoutUserInput>;
 };
 
 export type UserCreateManyInput = {
@@ -5034,6 +5113,24 @@ export type UserCreateNestedOneWithoutQuizAttemptsInput = {
   create?: InputMaybe<UserCreateWithoutQuizAttemptsInput>;
 };
 
+export type UserCreateNestedOneWithoutStreakInput = {
+  connect?: InputMaybe<UserWhereUniqueInput>;
+  connectOrCreate?: InputMaybe<UserCreateOrConnectWithoutStreakInput>;
+  create?: InputMaybe<UserCreateWithoutStreakInput>;
+};
+
+export type UserCreateNestedOneWithoutXpEventsInput = {
+  connect?: InputMaybe<UserWhereUniqueInput>;
+  connectOrCreate?: InputMaybe<UserCreateOrConnectWithoutXpEventsInput>;
+  create?: InputMaybe<UserCreateWithoutXpEventsInput>;
+};
+
+export type UserCreateNestedOneWithoutXpInput = {
+  connect?: InputMaybe<UserWhereUniqueInput>;
+  connectOrCreate?: InputMaybe<UserCreateOrConnectWithoutXpInput>;
+  create?: InputMaybe<UserCreateWithoutXpInput>;
+};
+
 export type UserCreateOrConnectWithoutCoursesAuthoredInput = {
   create: UserCreateWithoutCoursesAuthoredInput;
   where: UserWhereUniqueInput;
@@ -5049,6 +5146,21 @@ export type UserCreateOrConnectWithoutQuizAttemptsInput = {
   where: UserWhereUniqueInput;
 };
 
+export type UserCreateOrConnectWithoutStreakInput = {
+  create: UserCreateWithoutStreakInput;
+  where: UserWhereUniqueInput;
+};
+
+export type UserCreateOrConnectWithoutXpEventsInput = {
+  create: UserCreateWithoutXpEventsInput;
+  where: UserWhereUniqueInput;
+};
+
+export type UserCreateOrConnectWithoutXpInput = {
+  create: UserCreateWithoutXpInput;
+  where: UserWhereUniqueInput;
+};
+
 export type UserCreateWithoutCoursesAuthoredInput = {
   createdAt?: InputMaybe<Scalars['DateTime']['input']>;
   email: Scalars['String']['input'];
@@ -5058,7 +5170,10 @@ export type UserCreateWithoutCoursesAuthoredInput = {
   photoUrl?: InputMaybe<Scalars['String']['input']>;
   quizAttempts?: InputMaybe<QuizAttemptCreateNestedManyWithoutUserInput>;
   role?: InputMaybe<Role>;
+  streak?: InputMaybe<UserStreakCreateNestedOneWithoutUserInput>;
   updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  xp?: InputMaybe<UserXpCreateNestedOneWithoutUserInput>;
+  xpEvents?: InputMaybe<XpEventCreateNestedManyWithoutUserInput>;
 };
 
 export type UserCreateWithoutNodeProgressInput = {
@@ -5070,7 +5185,10 @@ export type UserCreateWithoutNodeProgressInput = {
   photoUrl?: InputMaybe<Scalars['String']['input']>;
   quizAttempts?: InputMaybe<QuizAttemptCreateNestedManyWithoutUserInput>;
   role?: InputMaybe<Role>;
+  streak?: InputMaybe<UserStreakCreateNestedOneWithoutUserInput>;
   updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  xp?: InputMaybe<UserXpCreateNestedOneWithoutUserInput>;
+  xpEvents?: InputMaybe<XpEventCreateNestedManyWithoutUserInput>;
 };
 
 export type UserCreateWithoutQuizAttemptsInput = {
@@ -5082,7 +5200,55 @@ export type UserCreateWithoutQuizAttemptsInput = {
   nodeProgress?: InputMaybe<UserNodeProgressCreateNestedManyWithoutUserInput>;
   photoUrl?: InputMaybe<Scalars['String']['input']>;
   role?: InputMaybe<Role>;
+  streak?: InputMaybe<UserStreakCreateNestedOneWithoutUserInput>;
   updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  xp?: InputMaybe<UserXpCreateNestedOneWithoutUserInput>;
+  xpEvents?: InputMaybe<XpEventCreateNestedManyWithoutUserInput>;
+};
+
+export type UserCreateWithoutStreakInput = {
+  coursesAuthored?: InputMaybe<CourseCreateNestedManyWithoutAuthorInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  email: Scalars['String']['input'];
+  id: Scalars['String']['input'];
+  name?: InputMaybe<Scalars['String']['input']>;
+  nodeProgress?: InputMaybe<UserNodeProgressCreateNestedManyWithoutUserInput>;
+  photoUrl?: InputMaybe<Scalars['String']['input']>;
+  quizAttempts?: InputMaybe<QuizAttemptCreateNestedManyWithoutUserInput>;
+  role?: InputMaybe<Role>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  xp?: InputMaybe<UserXpCreateNestedOneWithoutUserInput>;
+  xpEvents?: InputMaybe<XpEventCreateNestedManyWithoutUserInput>;
+};
+
+export type UserCreateWithoutXpEventsInput = {
+  coursesAuthored?: InputMaybe<CourseCreateNestedManyWithoutAuthorInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  email: Scalars['String']['input'];
+  id: Scalars['String']['input'];
+  name?: InputMaybe<Scalars['String']['input']>;
+  nodeProgress?: InputMaybe<UserNodeProgressCreateNestedManyWithoutUserInput>;
+  photoUrl?: InputMaybe<Scalars['String']['input']>;
+  quizAttempts?: InputMaybe<QuizAttemptCreateNestedManyWithoutUserInput>;
+  role?: InputMaybe<Role>;
+  streak?: InputMaybe<UserStreakCreateNestedOneWithoutUserInput>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  xp?: InputMaybe<UserXpCreateNestedOneWithoutUserInput>;
+};
+
+export type UserCreateWithoutXpInput = {
+  coursesAuthored?: InputMaybe<CourseCreateNestedManyWithoutAuthorInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  email: Scalars['String']['input'];
+  id: Scalars['String']['input'];
+  name?: InputMaybe<Scalars['String']['input']>;
+  nodeProgress?: InputMaybe<UserNodeProgressCreateNestedManyWithoutUserInput>;
+  photoUrl?: InputMaybe<Scalars['String']['input']>;
+  quizAttempts?: InputMaybe<QuizAttemptCreateNestedManyWithoutUserInput>;
+  role?: InputMaybe<Role>;
+  streak?: InputMaybe<UserStreakCreateNestedOneWithoutUserInput>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  xpEvents?: InputMaybe<XpEventCreateNestedManyWithoutUserInput>;
 };
 
 export type UserMaxOrderByAggregateInput = {
@@ -5463,7 +5629,10 @@ export type UserOrderByWithRelationInput = {
   photoUrl?: InputMaybe<SortOrder>;
   quizAttempts?: InputMaybe<QuizAttemptOrderByRelationAggregateInput>;
   role?: InputMaybe<SortOrder>;
+  streak?: InputMaybe<UserStreakOrderByWithRelationInput>;
   updatedAt?: InputMaybe<SortOrder>;
+  xp?: InputMaybe<UserXpOrderByWithRelationInput>;
+  xpEvents?: InputMaybe<XpEventOrderByRelationAggregateInput>;
 };
 
 export type UserScalarFieldEnum =
@@ -5493,6 +5662,180 @@ export type UserScalarWhereWithAggregatesInput = {
   updatedAt?: InputMaybe<DateTimeWithAggregatesFilter>;
 };
 
+export type UserStreak = {
+  __typename?: 'UserStreak';
+  currentDays: Scalars['Int']['output'];
+  lastActive?: Maybe<Scalars['DateTime']['output']>;
+  longestDays: Scalars['Int']['output'];
+  user: User;
+  userId: Scalars['ID']['output'];
+};
+
+export type UserStreakAvgOrderByAggregateInput = {
+  currentDays?: InputMaybe<SortOrder>;
+  longestDays?: InputMaybe<SortOrder>;
+};
+
+export type UserStreakCountOrderByAggregateInput = {
+  currentDays?: InputMaybe<SortOrder>;
+  lastActive?: InputMaybe<SortOrder>;
+  longestDays?: InputMaybe<SortOrder>;
+  userId?: InputMaybe<SortOrder>;
+};
+
+export type UserStreakCreateInput = {
+  currentDays?: InputMaybe<Scalars['Int']['input']>;
+  lastActive?: InputMaybe<Scalars['DateTime']['input']>;
+  longestDays?: InputMaybe<Scalars['Int']['input']>;
+  user: UserCreateNestedOneWithoutStreakInput;
+};
+
+export type UserStreakCreateManyInput = {
+  currentDays?: InputMaybe<Scalars['Int']['input']>;
+  lastActive?: InputMaybe<Scalars['DateTime']['input']>;
+  longestDays?: InputMaybe<Scalars['Int']['input']>;
+  userId: Scalars['String']['input'];
+};
+
+export type UserStreakCreateNestedOneWithoutUserInput = {
+  connect?: InputMaybe<UserStreakWhereUniqueInput>;
+  connectOrCreate?: InputMaybe<UserStreakCreateOrConnectWithoutUserInput>;
+  create?: InputMaybe<UserStreakCreateWithoutUserInput>;
+};
+
+export type UserStreakCreateOrConnectWithoutUserInput = {
+  create: UserStreakCreateWithoutUserInput;
+  where: UserStreakWhereUniqueInput;
+};
+
+export type UserStreakCreateWithoutUserInput = {
+  currentDays?: InputMaybe<Scalars['Int']['input']>;
+  lastActive?: InputMaybe<Scalars['DateTime']['input']>;
+  longestDays?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type UserStreakMaxOrderByAggregateInput = {
+  currentDays?: InputMaybe<SortOrder>;
+  lastActive?: InputMaybe<SortOrder>;
+  longestDays?: InputMaybe<SortOrder>;
+  userId?: InputMaybe<SortOrder>;
+};
+
+export type UserStreakMinOrderByAggregateInput = {
+  currentDays?: InputMaybe<SortOrder>;
+  lastActive?: InputMaybe<SortOrder>;
+  longestDays?: InputMaybe<SortOrder>;
+  userId?: InputMaybe<SortOrder>;
+};
+
+export type UserStreakNullableScalarRelationFilter = {
+  is?: InputMaybe<UserStreakWhereInput>;
+  isNot?: InputMaybe<UserStreakWhereInput>;
+};
+
+export type UserStreakOrderByWithAggregationInput = {
+  _avg?: InputMaybe<UserStreakAvgOrderByAggregateInput>;
+  _count?: InputMaybe<UserStreakCountOrderByAggregateInput>;
+  _max?: InputMaybe<UserStreakMaxOrderByAggregateInput>;
+  _min?: InputMaybe<UserStreakMinOrderByAggregateInput>;
+  _sum?: InputMaybe<UserStreakSumOrderByAggregateInput>;
+  currentDays?: InputMaybe<SortOrder>;
+  lastActive?: InputMaybe<SortOrder>;
+  longestDays?: InputMaybe<SortOrder>;
+  userId?: InputMaybe<SortOrder>;
+};
+
+export type UserStreakOrderByWithRelationInput = {
+  currentDays?: InputMaybe<SortOrder>;
+  lastActive?: InputMaybe<SortOrder>;
+  longestDays?: InputMaybe<SortOrder>;
+  user?: InputMaybe<UserOrderByWithRelationInput>;
+  userId?: InputMaybe<SortOrder>;
+};
+
+export type UserStreakScalarFieldEnum =
+  | 'currentDays'
+  | 'lastActive'
+  | 'longestDays'
+  | 'userId';
+
+export type UserStreakScalarWhereWithAggregatesInput = {
+  AND?: InputMaybe<Array<UserStreakScalarWhereWithAggregatesInput>>;
+  NOT?: InputMaybe<Array<UserStreakScalarWhereWithAggregatesInput>>;
+  OR?: InputMaybe<Array<UserStreakScalarWhereWithAggregatesInput>>;
+  currentDays?: InputMaybe<IntWithAggregatesFilter>;
+  lastActive?: InputMaybe<DateTimeNullableWithAggregatesFilter>;
+  longestDays?: InputMaybe<IntWithAggregatesFilter>;
+  userId?: InputMaybe<StringWithAggregatesFilter>;
+};
+
+export type UserStreakSumOrderByAggregateInput = {
+  currentDays?: InputMaybe<SortOrder>;
+  longestDays?: InputMaybe<SortOrder>;
+};
+
+export type UserStreakUpdateInput = {
+  currentDays?: InputMaybe<IntFieldUpdateOperationsInput>;
+  lastActive?: InputMaybe<NullableDateTimeFieldUpdateOperationsInput>;
+  longestDays?: InputMaybe<IntFieldUpdateOperationsInput>;
+  user?: InputMaybe<UserUpdateOneRequiredWithoutStreakNestedInput>;
+};
+
+export type UserStreakUpdateManyMutationInput = {
+  currentDays?: InputMaybe<IntFieldUpdateOperationsInput>;
+  lastActive?: InputMaybe<NullableDateTimeFieldUpdateOperationsInput>;
+  longestDays?: InputMaybe<IntFieldUpdateOperationsInput>;
+};
+
+export type UserStreakUpdateOneWithoutUserNestedInput = {
+  connect?: InputMaybe<UserStreakWhereUniqueInput>;
+  connectOrCreate?: InputMaybe<UserStreakCreateOrConnectWithoutUserInput>;
+  create?: InputMaybe<UserStreakCreateWithoutUserInput>;
+  delete?: InputMaybe<UserStreakWhereInput>;
+  disconnect?: InputMaybe<UserStreakWhereInput>;
+  update?: InputMaybe<UserStreakUpdateToOneWithWhereWithoutUserInput>;
+  upsert?: InputMaybe<UserStreakUpsertWithoutUserInput>;
+};
+
+export type UserStreakUpdateToOneWithWhereWithoutUserInput = {
+  data: UserStreakUpdateWithoutUserInput;
+  where?: InputMaybe<UserStreakWhereInput>;
+};
+
+export type UserStreakUpdateWithoutUserInput = {
+  currentDays?: InputMaybe<IntFieldUpdateOperationsInput>;
+  lastActive?: InputMaybe<NullableDateTimeFieldUpdateOperationsInput>;
+  longestDays?: InputMaybe<IntFieldUpdateOperationsInput>;
+};
+
+export type UserStreakUpsertWithoutUserInput = {
+  create: UserStreakCreateWithoutUserInput;
+  update: UserStreakUpdateWithoutUserInput;
+  where?: InputMaybe<UserStreakWhereInput>;
+};
+
+export type UserStreakWhereInput = {
+  AND?: InputMaybe<Array<UserStreakWhereInput>>;
+  NOT?: InputMaybe<Array<UserStreakWhereInput>>;
+  OR?: InputMaybe<Array<UserStreakWhereInput>>;
+  currentDays?: InputMaybe<IntFilter>;
+  lastActive?: InputMaybe<DateTimeNullableFilter>;
+  longestDays?: InputMaybe<IntFilter>;
+  user?: InputMaybe<UserWhereInput>;
+  userId?: InputMaybe<StringFilter>;
+};
+
+export type UserStreakWhereUniqueInput = {
+  AND?: InputMaybe<Array<UserStreakWhereInput>>;
+  NOT?: InputMaybe<Array<UserStreakWhereInput>>;
+  OR?: InputMaybe<Array<UserStreakWhereInput>>;
+  currentDays?: InputMaybe<IntFilter>;
+  lastActive?: InputMaybe<DateTimeNullableFilter>;
+  longestDays?: InputMaybe<IntFilter>;
+  user?: InputMaybe<UserWhereInput>;
+  userId?: InputMaybe<Scalars['String']['input']>;
+};
+
 export type UserUpdateInput = {
   coursesAuthored?: InputMaybe<CourseUpdateManyWithoutAuthorNestedInput>;
   createdAt?: InputMaybe<DateTimeFieldUpdateOperationsInput>;
@@ -5503,7 +5846,10 @@ export type UserUpdateInput = {
   photoUrl?: InputMaybe<NullableStringFieldUpdateOperationsInput>;
   quizAttempts?: InputMaybe<QuizAttemptUpdateManyWithoutUserNestedInput>;
   role?: InputMaybe<EnumRoleFieldUpdateOperationsInput>;
+  streak?: InputMaybe<UserStreakUpdateOneWithoutUserNestedInput>;
   updatedAt?: InputMaybe<DateTimeFieldUpdateOperationsInput>;
+  xp?: InputMaybe<UserXpUpdateOneWithoutUserNestedInput>;
+  xpEvents?: InputMaybe<XpEventUpdateManyWithoutUserNestedInput>;
 };
 
 export type UserUpdateManyMutationInput = {
@@ -5540,6 +5886,30 @@ export type UserUpdateOneRequiredWithoutQuizAttemptsNestedInput = {
   upsert?: InputMaybe<UserUpsertWithoutQuizAttemptsInput>;
 };
 
+export type UserUpdateOneRequiredWithoutStreakNestedInput = {
+  connect?: InputMaybe<UserWhereUniqueInput>;
+  connectOrCreate?: InputMaybe<UserCreateOrConnectWithoutStreakInput>;
+  create?: InputMaybe<UserCreateWithoutStreakInput>;
+  update?: InputMaybe<UserUpdateToOneWithWhereWithoutStreakInput>;
+  upsert?: InputMaybe<UserUpsertWithoutStreakInput>;
+};
+
+export type UserUpdateOneRequiredWithoutXpEventsNestedInput = {
+  connect?: InputMaybe<UserWhereUniqueInput>;
+  connectOrCreate?: InputMaybe<UserCreateOrConnectWithoutXpEventsInput>;
+  create?: InputMaybe<UserCreateWithoutXpEventsInput>;
+  update?: InputMaybe<UserUpdateToOneWithWhereWithoutXpEventsInput>;
+  upsert?: InputMaybe<UserUpsertWithoutXpEventsInput>;
+};
+
+export type UserUpdateOneRequiredWithoutXpNestedInput = {
+  connect?: InputMaybe<UserWhereUniqueInput>;
+  connectOrCreate?: InputMaybe<UserCreateOrConnectWithoutXpInput>;
+  create?: InputMaybe<UserCreateWithoutXpInput>;
+  update?: InputMaybe<UserUpdateToOneWithWhereWithoutXpInput>;
+  upsert?: InputMaybe<UserUpsertWithoutXpInput>;
+};
+
 export type UserUpdateToOneWithWhereWithoutCoursesAuthoredInput = {
   data: UserUpdateWithoutCoursesAuthoredInput;
   where?: InputMaybe<UserWhereInput>;
@@ -5555,6 +5925,21 @@ export type UserUpdateToOneWithWhereWithoutQuizAttemptsInput = {
   where?: InputMaybe<UserWhereInput>;
 };
 
+export type UserUpdateToOneWithWhereWithoutStreakInput = {
+  data: UserUpdateWithoutStreakInput;
+  where?: InputMaybe<UserWhereInput>;
+};
+
+export type UserUpdateToOneWithWhereWithoutXpEventsInput = {
+  data: UserUpdateWithoutXpEventsInput;
+  where?: InputMaybe<UserWhereInput>;
+};
+
+export type UserUpdateToOneWithWhereWithoutXpInput = {
+  data: UserUpdateWithoutXpInput;
+  where?: InputMaybe<UserWhereInput>;
+};
+
 export type UserUpdateWithoutCoursesAuthoredInput = {
   createdAt?: InputMaybe<DateTimeFieldUpdateOperationsInput>;
   email?: InputMaybe<StringFieldUpdateOperationsInput>;
@@ -5564,7 +5949,10 @@ export type UserUpdateWithoutCoursesAuthoredInput = {
   photoUrl?: InputMaybe<NullableStringFieldUpdateOperationsInput>;
   quizAttempts?: InputMaybe<QuizAttemptUpdateManyWithoutUserNestedInput>;
   role?: InputMaybe<EnumRoleFieldUpdateOperationsInput>;
+  streak?: InputMaybe<UserStreakUpdateOneWithoutUserNestedInput>;
   updatedAt?: InputMaybe<DateTimeFieldUpdateOperationsInput>;
+  xp?: InputMaybe<UserXpUpdateOneWithoutUserNestedInput>;
+  xpEvents?: InputMaybe<XpEventUpdateManyWithoutUserNestedInput>;
 };
 
 export type UserUpdateWithoutNodeProgressInput = {
@@ -5576,7 +5964,10 @@ export type UserUpdateWithoutNodeProgressInput = {
   photoUrl?: InputMaybe<NullableStringFieldUpdateOperationsInput>;
   quizAttempts?: InputMaybe<QuizAttemptUpdateManyWithoutUserNestedInput>;
   role?: InputMaybe<EnumRoleFieldUpdateOperationsInput>;
+  streak?: InputMaybe<UserStreakUpdateOneWithoutUserNestedInput>;
   updatedAt?: InputMaybe<DateTimeFieldUpdateOperationsInput>;
+  xp?: InputMaybe<UserXpUpdateOneWithoutUserNestedInput>;
+  xpEvents?: InputMaybe<XpEventUpdateManyWithoutUserNestedInput>;
 };
 
 export type UserUpdateWithoutQuizAttemptsInput = {
@@ -5588,7 +5979,55 @@ export type UserUpdateWithoutQuizAttemptsInput = {
   nodeProgress?: InputMaybe<UserNodeProgressUpdateManyWithoutUserNestedInput>;
   photoUrl?: InputMaybe<NullableStringFieldUpdateOperationsInput>;
   role?: InputMaybe<EnumRoleFieldUpdateOperationsInput>;
+  streak?: InputMaybe<UserStreakUpdateOneWithoutUserNestedInput>;
   updatedAt?: InputMaybe<DateTimeFieldUpdateOperationsInput>;
+  xp?: InputMaybe<UserXpUpdateOneWithoutUserNestedInput>;
+  xpEvents?: InputMaybe<XpEventUpdateManyWithoutUserNestedInput>;
+};
+
+export type UserUpdateWithoutStreakInput = {
+  coursesAuthored?: InputMaybe<CourseUpdateManyWithoutAuthorNestedInput>;
+  createdAt?: InputMaybe<DateTimeFieldUpdateOperationsInput>;
+  email?: InputMaybe<StringFieldUpdateOperationsInput>;
+  id?: InputMaybe<StringFieldUpdateOperationsInput>;
+  name?: InputMaybe<NullableStringFieldUpdateOperationsInput>;
+  nodeProgress?: InputMaybe<UserNodeProgressUpdateManyWithoutUserNestedInput>;
+  photoUrl?: InputMaybe<NullableStringFieldUpdateOperationsInput>;
+  quizAttempts?: InputMaybe<QuizAttemptUpdateManyWithoutUserNestedInput>;
+  role?: InputMaybe<EnumRoleFieldUpdateOperationsInput>;
+  updatedAt?: InputMaybe<DateTimeFieldUpdateOperationsInput>;
+  xp?: InputMaybe<UserXpUpdateOneWithoutUserNestedInput>;
+  xpEvents?: InputMaybe<XpEventUpdateManyWithoutUserNestedInput>;
+};
+
+export type UserUpdateWithoutXpEventsInput = {
+  coursesAuthored?: InputMaybe<CourseUpdateManyWithoutAuthorNestedInput>;
+  createdAt?: InputMaybe<DateTimeFieldUpdateOperationsInput>;
+  email?: InputMaybe<StringFieldUpdateOperationsInput>;
+  id?: InputMaybe<StringFieldUpdateOperationsInput>;
+  name?: InputMaybe<NullableStringFieldUpdateOperationsInput>;
+  nodeProgress?: InputMaybe<UserNodeProgressUpdateManyWithoutUserNestedInput>;
+  photoUrl?: InputMaybe<NullableStringFieldUpdateOperationsInput>;
+  quizAttempts?: InputMaybe<QuizAttemptUpdateManyWithoutUserNestedInput>;
+  role?: InputMaybe<EnumRoleFieldUpdateOperationsInput>;
+  streak?: InputMaybe<UserStreakUpdateOneWithoutUserNestedInput>;
+  updatedAt?: InputMaybe<DateTimeFieldUpdateOperationsInput>;
+  xp?: InputMaybe<UserXpUpdateOneWithoutUserNestedInput>;
+};
+
+export type UserUpdateWithoutXpInput = {
+  coursesAuthored?: InputMaybe<CourseUpdateManyWithoutAuthorNestedInput>;
+  createdAt?: InputMaybe<DateTimeFieldUpdateOperationsInput>;
+  email?: InputMaybe<StringFieldUpdateOperationsInput>;
+  id?: InputMaybe<StringFieldUpdateOperationsInput>;
+  name?: InputMaybe<NullableStringFieldUpdateOperationsInput>;
+  nodeProgress?: InputMaybe<UserNodeProgressUpdateManyWithoutUserNestedInput>;
+  photoUrl?: InputMaybe<NullableStringFieldUpdateOperationsInput>;
+  quizAttempts?: InputMaybe<QuizAttemptUpdateManyWithoutUserNestedInput>;
+  role?: InputMaybe<EnumRoleFieldUpdateOperationsInput>;
+  streak?: InputMaybe<UserStreakUpdateOneWithoutUserNestedInput>;
+  updatedAt?: InputMaybe<DateTimeFieldUpdateOperationsInput>;
+  xpEvents?: InputMaybe<XpEventUpdateManyWithoutUserNestedInput>;
 };
 
 export type UserUpsertWithoutCoursesAuthoredInput = {
@@ -5609,6 +6048,24 @@ export type UserUpsertWithoutQuizAttemptsInput = {
   where?: InputMaybe<UserWhereInput>;
 };
 
+export type UserUpsertWithoutStreakInput = {
+  create: UserCreateWithoutStreakInput;
+  update: UserUpdateWithoutStreakInput;
+  where?: InputMaybe<UserWhereInput>;
+};
+
+export type UserUpsertWithoutXpEventsInput = {
+  create: UserCreateWithoutXpEventsInput;
+  update: UserUpdateWithoutXpEventsInput;
+  where?: InputMaybe<UserWhereInput>;
+};
+
+export type UserUpsertWithoutXpInput = {
+  create: UserCreateWithoutXpInput;
+  update: UserUpdateWithoutXpInput;
+  where?: InputMaybe<UserWhereInput>;
+};
+
 export type UserWhereInput = {
   AND?: InputMaybe<Array<UserWhereInput>>;
   NOT?: InputMaybe<Array<UserWhereInput>>;
@@ -5622,7 +6079,10 @@ export type UserWhereInput = {
   photoUrl?: InputMaybe<StringNullableFilter>;
   quizAttempts?: InputMaybe<QuizAttemptListRelationFilter>;
   role?: InputMaybe<EnumRoleFilter>;
+  streak?: InputMaybe<UserStreakWhereInput>;
   updatedAt?: InputMaybe<DateTimeFilter>;
+  xp?: InputMaybe<UserXpWhereInput>;
+  xpEvents?: InputMaybe<XpEventListRelationFilter>;
 };
 
 export type UserWhereUniqueInput = {
@@ -5638,7 +6098,198 @@ export type UserWhereUniqueInput = {
   photoUrl?: InputMaybe<StringNullableFilter>;
   quizAttempts?: InputMaybe<QuizAttemptListRelationFilter>;
   role?: InputMaybe<EnumRoleFilter>;
+  streak?: InputMaybe<UserStreakWhereInput>;
   updatedAt?: InputMaybe<DateTimeFilter>;
+  xp?: InputMaybe<UserXpWhereInput>;
+  xpEvents?: InputMaybe<XpEventListRelationFilter>;
+};
+
+export type UserXp = {
+  __typename?: 'UserXp';
+  todayAsOf: Scalars['DateTime']['output'];
+  todayXp: Scalars['Int']['output'];
+  totalXp: Scalars['Int']['output'];
+  user: User;
+  userId: Scalars['ID']['output'];
+  weeklyXp: Scalars['Json']['output'];
+};
+
+export type UserXpAvgOrderByAggregateInput = {
+  todayXp?: InputMaybe<SortOrder>;
+  totalXp?: InputMaybe<SortOrder>;
+};
+
+export type UserXpCountOrderByAggregateInput = {
+  todayAsOf?: InputMaybe<SortOrder>;
+  todayXp?: InputMaybe<SortOrder>;
+  totalXp?: InputMaybe<SortOrder>;
+  userId?: InputMaybe<SortOrder>;
+  weeklyXp?: InputMaybe<SortOrder>;
+};
+
+export type UserXpCreateInput = {
+  todayAsOf?: InputMaybe<Scalars['DateTime']['input']>;
+  todayXp?: InputMaybe<Scalars['Int']['input']>;
+  totalXp?: InputMaybe<Scalars['Int']['input']>;
+  user: UserCreateNestedOneWithoutXpInput;
+  weeklyXp?: InputMaybe<Scalars['Json']['input']>;
+};
+
+export type UserXpCreateManyInput = {
+  todayAsOf?: InputMaybe<Scalars['DateTime']['input']>;
+  todayXp?: InputMaybe<Scalars['Int']['input']>;
+  totalXp?: InputMaybe<Scalars['Int']['input']>;
+  userId: Scalars['String']['input'];
+  weeklyXp?: InputMaybe<Scalars['Json']['input']>;
+};
+
+export type UserXpCreateNestedOneWithoutUserInput = {
+  connect?: InputMaybe<UserXpWhereUniqueInput>;
+  connectOrCreate?: InputMaybe<UserXpCreateOrConnectWithoutUserInput>;
+  create?: InputMaybe<UserXpCreateWithoutUserInput>;
+};
+
+export type UserXpCreateOrConnectWithoutUserInput = {
+  create: UserXpCreateWithoutUserInput;
+  where: UserXpWhereUniqueInput;
+};
+
+export type UserXpCreateWithoutUserInput = {
+  todayAsOf?: InputMaybe<Scalars['DateTime']['input']>;
+  todayXp?: InputMaybe<Scalars['Int']['input']>;
+  totalXp?: InputMaybe<Scalars['Int']['input']>;
+  weeklyXp?: InputMaybe<Scalars['Json']['input']>;
+};
+
+export type UserXpMaxOrderByAggregateInput = {
+  todayAsOf?: InputMaybe<SortOrder>;
+  todayXp?: InputMaybe<SortOrder>;
+  totalXp?: InputMaybe<SortOrder>;
+  userId?: InputMaybe<SortOrder>;
+};
+
+export type UserXpMinOrderByAggregateInput = {
+  todayAsOf?: InputMaybe<SortOrder>;
+  todayXp?: InputMaybe<SortOrder>;
+  totalXp?: InputMaybe<SortOrder>;
+  userId?: InputMaybe<SortOrder>;
+};
+
+export type UserXpNullableScalarRelationFilter = {
+  is?: InputMaybe<UserXpWhereInput>;
+  isNot?: InputMaybe<UserXpWhereInput>;
+};
+
+export type UserXpOrderByWithAggregationInput = {
+  _avg?: InputMaybe<UserXpAvgOrderByAggregateInput>;
+  _count?: InputMaybe<UserXpCountOrderByAggregateInput>;
+  _max?: InputMaybe<UserXpMaxOrderByAggregateInput>;
+  _min?: InputMaybe<UserXpMinOrderByAggregateInput>;
+  _sum?: InputMaybe<UserXpSumOrderByAggregateInput>;
+  todayAsOf?: InputMaybe<SortOrder>;
+  todayXp?: InputMaybe<SortOrder>;
+  totalXp?: InputMaybe<SortOrder>;
+  userId?: InputMaybe<SortOrder>;
+  weeklyXp?: InputMaybe<SortOrder>;
+};
+
+export type UserXpOrderByWithRelationInput = {
+  todayAsOf?: InputMaybe<SortOrder>;
+  todayXp?: InputMaybe<SortOrder>;
+  totalXp?: InputMaybe<SortOrder>;
+  user?: InputMaybe<UserOrderByWithRelationInput>;
+  userId?: InputMaybe<SortOrder>;
+  weeklyXp?: InputMaybe<SortOrder>;
+};
+
+export type UserXpScalarFieldEnum =
+  | 'todayAsOf'
+  | 'todayXp'
+  | 'totalXp'
+  | 'userId'
+  | 'weeklyXp';
+
+export type UserXpScalarWhereWithAggregatesInput = {
+  AND?: InputMaybe<Array<UserXpScalarWhereWithAggregatesInput>>;
+  NOT?: InputMaybe<Array<UserXpScalarWhereWithAggregatesInput>>;
+  OR?: InputMaybe<Array<UserXpScalarWhereWithAggregatesInput>>;
+  todayAsOf?: InputMaybe<DateTimeWithAggregatesFilter>;
+  todayXp?: InputMaybe<IntWithAggregatesFilter>;
+  totalXp?: InputMaybe<IntWithAggregatesFilter>;
+  userId?: InputMaybe<StringWithAggregatesFilter>;
+  weeklyXp?: InputMaybe<JsonWithAggregatesFilter>;
+};
+
+export type UserXpSumOrderByAggregateInput = {
+  todayXp?: InputMaybe<SortOrder>;
+  totalXp?: InputMaybe<SortOrder>;
+};
+
+export type UserXpUpdateInput = {
+  todayAsOf?: InputMaybe<DateTimeFieldUpdateOperationsInput>;
+  todayXp?: InputMaybe<IntFieldUpdateOperationsInput>;
+  totalXp?: InputMaybe<IntFieldUpdateOperationsInput>;
+  user?: InputMaybe<UserUpdateOneRequiredWithoutXpNestedInput>;
+  weeklyXp?: InputMaybe<Scalars['Json']['input']>;
+};
+
+export type UserXpUpdateManyMutationInput = {
+  todayAsOf?: InputMaybe<DateTimeFieldUpdateOperationsInput>;
+  todayXp?: InputMaybe<IntFieldUpdateOperationsInput>;
+  totalXp?: InputMaybe<IntFieldUpdateOperationsInput>;
+  weeklyXp?: InputMaybe<Scalars['Json']['input']>;
+};
+
+export type UserXpUpdateOneWithoutUserNestedInput = {
+  connect?: InputMaybe<UserXpWhereUniqueInput>;
+  connectOrCreate?: InputMaybe<UserXpCreateOrConnectWithoutUserInput>;
+  create?: InputMaybe<UserXpCreateWithoutUserInput>;
+  delete?: InputMaybe<UserXpWhereInput>;
+  disconnect?: InputMaybe<UserXpWhereInput>;
+  update?: InputMaybe<UserXpUpdateToOneWithWhereWithoutUserInput>;
+  upsert?: InputMaybe<UserXpUpsertWithoutUserInput>;
+};
+
+export type UserXpUpdateToOneWithWhereWithoutUserInput = {
+  data: UserXpUpdateWithoutUserInput;
+  where?: InputMaybe<UserXpWhereInput>;
+};
+
+export type UserXpUpdateWithoutUserInput = {
+  todayAsOf?: InputMaybe<DateTimeFieldUpdateOperationsInput>;
+  todayXp?: InputMaybe<IntFieldUpdateOperationsInput>;
+  totalXp?: InputMaybe<IntFieldUpdateOperationsInput>;
+  weeklyXp?: InputMaybe<Scalars['Json']['input']>;
+};
+
+export type UserXpUpsertWithoutUserInput = {
+  create: UserXpCreateWithoutUserInput;
+  update: UserXpUpdateWithoutUserInput;
+  where?: InputMaybe<UserXpWhereInput>;
+};
+
+export type UserXpWhereInput = {
+  AND?: InputMaybe<Array<UserXpWhereInput>>;
+  NOT?: InputMaybe<Array<UserXpWhereInput>>;
+  OR?: InputMaybe<Array<UserXpWhereInput>>;
+  todayAsOf?: InputMaybe<DateTimeFilter>;
+  todayXp?: InputMaybe<IntFilter>;
+  totalXp?: InputMaybe<IntFilter>;
+  user?: InputMaybe<UserWhereInput>;
+  userId?: InputMaybe<StringFilter>;
+  weeklyXp?: InputMaybe<JsonFilter>;
+};
+
+export type UserXpWhereUniqueInput = {
+  AND?: InputMaybe<Array<UserXpWhereInput>>;
+  NOT?: InputMaybe<Array<UserXpWhereInput>>;
+  OR?: InputMaybe<Array<UserXpWhereInput>>;
+  todayAsOf?: InputMaybe<DateTimeFilter>;
+  todayXp?: InputMaybe<IntFilter>;
+  totalXp?: InputMaybe<IntFilter>;
+  user?: InputMaybe<UserWhereInput>;
+  userId?: InputMaybe<Scalars['String']['input']>;
+  weeklyXp?: InputMaybe<JsonFilter>;
 };
 
 export type UuidFilter = {
@@ -5666,6 +6317,248 @@ export type UuidWithAggregatesFilter = {
   mode?: InputMaybe<QueryMode>;
   not?: InputMaybe<NestedUuidWithAggregatesFilter>;
   notIn?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
+export type XpEvent = {
+  __typename?: 'XpEvent';
+  amount: Scalars['Int']['output'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['ID']['output'];
+  metadata?: Maybe<Scalars['Json']['output']>;
+  reason: Scalars['String']['output'];
+  user: User;
+  userId: Scalars['String']['output'];
+};
+
+export type XpEventAvgOrderByAggregateInput = {
+  amount?: InputMaybe<SortOrder>;
+};
+
+export type XpEventCountOrderByAggregateInput = {
+  amount?: InputMaybe<SortOrder>;
+  createdAt?: InputMaybe<SortOrder>;
+  id?: InputMaybe<SortOrder>;
+  metadata?: InputMaybe<SortOrder>;
+  reason?: InputMaybe<SortOrder>;
+  userId?: InputMaybe<SortOrder>;
+};
+
+export type XpEventCreateInput = {
+  amount: Scalars['Int']['input'];
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  id?: InputMaybe<Scalars['String']['input']>;
+  metadata?: InputMaybe<Scalars['Json']['input']>;
+  reason: Scalars['String']['input'];
+  user: UserCreateNestedOneWithoutXpEventsInput;
+};
+
+export type XpEventCreateManyInput = {
+  amount: Scalars['Int']['input'];
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  id?: InputMaybe<Scalars['String']['input']>;
+  metadata?: InputMaybe<Scalars['Json']['input']>;
+  reason: Scalars['String']['input'];
+  userId: Scalars['String']['input'];
+};
+
+export type XpEventCreateManyUserInput = {
+  amount: Scalars['Int']['input'];
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  id?: InputMaybe<Scalars['String']['input']>;
+  metadata?: InputMaybe<Scalars['Json']['input']>;
+  reason: Scalars['String']['input'];
+};
+
+export type XpEventCreateManyUserInputEnvelope = {
+  data: Array<XpEventCreateManyUserInput>;
+  skipDuplicates?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type XpEventCreateNestedManyWithoutUserInput = {
+  connect?: InputMaybe<Array<XpEventWhereUniqueInput>>;
+  connectOrCreate?: InputMaybe<Array<XpEventCreateOrConnectWithoutUserInput>>;
+  create?: InputMaybe<Array<XpEventCreateWithoutUserInput>>;
+  createMany?: InputMaybe<XpEventCreateManyUserInputEnvelope>;
+};
+
+export type XpEventCreateOrConnectWithoutUserInput = {
+  create: XpEventCreateWithoutUserInput;
+  where: XpEventWhereUniqueInput;
+};
+
+export type XpEventCreateWithoutUserInput = {
+  amount: Scalars['Int']['input'];
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  id?: InputMaybe<Scalars['String']['input']>;
+  metadata?: InputMaybe<Scalars['Json']['input']>;
+  reason: Scalars['String']['input'];
+};
+
+export type XpEventListRelationFilter = {
+  every?: InputMaybe<XpEventWhereInput>;
+  none?: InputMaybe<XpEventWhereInput>;
+  some?: InputMaybe<XpEventWhereInput>;
+};
+
+export type XpEventMaxOrderByAggregateInput = {
+  amount?: InputMaybe<SortOrder>;
+  createdAt?: InputMaybe<SortOrder>;
+  id?: InputMaybe<SortOrder>;
+  reason?: InputMaybe<SortOrder>;
+  userId?: InputMaybe<SortOrder>;
+};
+
+export type XpEventMinOrderByAggregateInput = {
+  amount?: InputMaybe<SortOrder>;
+  createdAt?: InputMaybe<SortOrder>;
+  id?: InputMaybe<SortOrder>;
+  reason?: InputMaybe<SortOrder>;
+  userId?: InputMaybe<SortOrder>;
+};
+
+export type XpEventOrderByRelationAggregateInput = {
+  _count?: InputMaybe<SortOrder>;
+};
+
+export type XpEventOrderByWithAggregationInput = {
+  _avg?: InputMaybe<XpEventAvgOrderByAggregateInput>;
+  _count?: InputMaybe<XpEventCountOrderByAggregateInput>;
+  _max?: InputMaybe<XpEventMaxOrderByAggregateInput>;
+  _min?: InputMaybe<XpEventMinOrderByAggregateInput>;
+  _sum?: InputMaybe<XpEventSumOrderByAggregateInput>;
+  amount?: InputMaybe<SortOrder>;
+  createdAt?: InputMaybe<SortOrder>;
+  id?: InputMaybe<SortOrder>;
+  metadata?: InputMaybe<SortOrder>;
+  reason?: InputMaybe<SortOrder>;
+  userId?: InputMaybe<SortOrder>;
+};
+
+export type XpEventOrderByWithRelationInput = {
+  amount?: InputMaybe<SortOrder>;
+  createdAt?: InputMaybe<SortOrder>;
+  id?: InputMaybe<SortOrder>;
+  metadata?: InputMaybe<SortOrder>;
+  reason?: InputMaybe<SortOrder>;
+  user?: InputMaybe<UserOrderByWithRelationInput>;
+  userId?: InputMaybe<SortOrder>;
+};
+
+export type XpEventScalarFieldEnum =
+  | 'amount'
+  | 'createdAt'
+  | 'id'
+  | 'metadata'
+  | 'reason'
+  | 'userId';
+
+export type XpEventScalarWhereInput = {
+  AND?: InputMaybe<Array<XpEventScalarWhereInput>>;
+  NOT?: InputMaybe<Array<XpEventScalarWhereInput>>;
+  OR?: InputMaybe<Array<XpEventScalarWhereInput>>;
+  amount?: InputMaybe<IntFilter>;
+  createdAt?: InputMaybe<DateTimeFilter>;
+  id?: InputMaybe<UuidFilter>;
+  metadata?: InputMaybe<JsonNullableFilter>;
+  reason?: InputMaybe<StringFilter>;
+  userId?: InputMaybe<StringFilter>;
+};
+
+export type XpEventScalarWhereWithAggregatesInput = {
+  AND?: InputMaybe<Array<XpEventScalarWhereWithAggregatesInput>>;
+  NOT?: InputMaybe<Array<XpEventScalarWhereWithAggregatesInput>>;
+  OR?: InputMaybe<Array<XpEventScalarWhereWithAggregatesInput>>;
+  amount?: InputMaybe<IntWithAggregatesFilter>;
+  createdAt?: InputMaybe<DateTimeWithAggregatesFilter>;
+  id?: InputMaybe<UuidWithAggregatesFilter>;
+  metadata?: InputMaybe<JsonNullableWithAggregatesFilter>;
+  reason?: InputMaybe<StringWithAggregatesFilter>;
+  userId?: InputMaybe<StringWithAggregatesFilter>;
+};
+
+export type XpEventSumOrderByAggregateInput = {
+  amount?: InputMaybe<SortOrder>;
+};
+
+export type XpEventUpdateInput = {
+  amount?: InputMaybe<IntFieldUpdateOperationsInput>;
+  createdAt?: InputMaybe<DateTimeFieldUpdateOperationsInput>;
+  id?: InputMaybe<StringFieldUpdateOperationsInput>;
+  metadata?: InputMaybe<Scalars['Json']['input']>;
+  reason?: InputMaybe<StringFieldUpdateOperationsInput>;
+  user?: InputMaybe<UserUpdateOneRequiredWithoutXpEventsNestedInput>;
+};
+
+export type XpEventUpdateManyMutationInput = {
+  amount?: InputMaybe<IntFieldUpdateOperationsInput>;
+  createdAt?: InputMaybe<DateTimeFieldUpdateOperationsInput>;
+  id?: InputMaybe<StringFieldUpdateOperationsInput>;
+  metadata?: InputMaybe<Scalars['Json']['input']>;
+  reason?: InputMaybe<StringFieldUpdateOperationsInput>;
+};
+
+export type XpEventUpdateManyWithWhereWithoutUserInput = {
+  data: XpEventUpdateManyMutationInput;
+  where: XpEventScalarWhereInput;
+};
+
+export type XpEventUpdateManyWithoutUserNestedInput = {
+  connect?: InputMaybe<Array<XpEventWhereUniqueInput>>;
+  connectOrCreate?: InputMaybe<Array<XpEventCreateOrConnectWithoutUserInput>>;
+  create?: InputMaybe<Array<XpEventCreateWithoutUserInput>>;
+  createMany?: InputMaybe<XpEventCreateManyUserInputEnvelope>;
+  delete?: InputMaybe<Array<XpEventWhereUniqueInput>>;
+  deleteMany?: InputMaybe<Array<XpEventScalarWhereInput>>;
+  disconnect?: InputMaybe<Array<XpEventWhereUniqueInput>>;
+  set?: InputMaybe<Array<XpEventWhereUniqueInput>>;
+  update?: InputMaybe<Array<XpEventUpdateWithWhereUniqueWithoutUserInput>>;
+  updateMany?: InputMaybe<Array<XpEventUpdateManyWithWhereWithoutUserInput>>;
+  upsert?: InputMaybe<Array<XpEventUpsertWithWhereUniqueWithoutUserInput>>;
+};
+
+export type XpEventUpdateWithWhereUniqueWithoutUserInput = {
+  data: XpEventUpdateWithoutUserInput;
+  where: XpEventWhereUniqueInput;
+};
+
+export type XpEventUpdateWithoutUserInput = {
+  amount?: InputMaybe<IntFieldUpdateOperationsInput>;
+  createdAt?: InputMaybe<DateTimeFieldUpdateOperationsInput>;
+  id?: InputMaybe<StringFieldUpdateOperationsInput>;
+  metadata?: InputMaybe<Scalars['Json']['input']>;
+  reason?: InputMaybe<StringFieldUpdateOperationsInput>;
+};
+
+export type XpEventUpsertWithWhereUniqueWithoutUserInput = {
+  create: XpEventCreateWithoutUserInput;
+  update: XpEventUpdateWithoutUserInput;
+  where: XpEventWhereUniqueInput;
+};
+
+export type XpEventWhereInput = {
+  AND?: InputMaybe<Array<XpEventWhereInput>>;
+  NOT?: InputMaybe<Array<XpEventWhereInput>>;
+  OR?: InputMaybe<Array<XpEventWhereInput>>;
+  amount?: InputMaybe<IntFilter>;
+  createdAt?: InputMaybe<DateTimeFilter>;
+  id?: InputMaybe<UuidFilter>;
+  metadata?: InputMaybe<JsonNullableFilter>;
+  reason?: InputMaybe<StringFilter>;
+  user?: InputMaybe<UserWhereInput>;
+  userId?: InputMaybe<StringFilter>;
+};
+
+export type XpEventWhereUniqueInput = {
+  AND?: InputMaybe<Array<XpEventWhereInput>>;
+  NOT?: InputMaybe<Array<XpEventWhereInput>>;
+  OR?: InputMaybe<Array<XpEventWhereInput>>;
+  amount?: InputMaybe<IntFilter>;
+  createdAt?: InputMaybe<DateTimeFilter>;
+  id?: InputMaybe<Scalars['String']['input']>;
+  metadata?: InputMaybe<JsonNullableFilter>;
+  reason?: InputMaybe<StringFilter>;
+  user?: InputMaybe<UserWhereInput>;
+  userId?: InputMaybe<StringFilter>;
 };
 
 export type AdminGetAllCoursesQueryVariables = Exact<{ [key: string]: never; }>;
@@ -5706,6 +6599,21 @@ export type CreateCourseMutationVariables = Exact<{
 
 export type CreateCourseMutation = { __typename?: 'Mutation', createCourse?: { __typename?: 'Course', id: string, title: string } | null };
 
+export type StartNodeProgressMutationVariables = Exact<{
+  nodeId: Scalars['ID']['input'];
+}>;
+
+
+export type StartNodeProgressMutation = { __typename?: 'Mutation', startNodeProgress?: { __typename?: 'UserNodeProgress', id: string, status: ProgressStatus } | null };
+
+export type SubmitQuizAttemptMutationVariables = Exact<{
+  quizId: Scalars['ID']['input'];
+  answers: Array<Scalars['String']['input']> | Scalars['String']['input'];
+}>;
+
+
+export type SubmitQuizAttemptMutation = { __typename?: 'Mutation', submitQuizAttempt?: { __typename?: 'QuizAttempt', id: string, passed: boolean } | null };
+
 export type SyncCurrentUserMutationVariables = Exact<{
   name?: InputMaybe<Scalars['String']['input']>;
   photoUrl?: InputMaybe<Scalars['String']['input']>;
@@ -5726,7 +6634,7 @@ export type PublicCourseQueryVariables = Exact<{
 }>;
 
 
-export type PublicCourseQuery = { __typename?: 'Query', publicCourse?: { __typename?: 'Course', id: string, title: string, description?: string | null, status: CourseStatus, trees: Array<{ __typename?: 'SkillTree', id: string, title: string, description?: string | null }> } | null };
+export type PublicCourseQuery = { __typename?: 'Query', publicCourse?: { __typename?: 'Course', id: string, title: string, description?: string | null, status: CourseStatus, trees: Array<{ __typename?: 'SkillTree', id: string, title: string, description?: string | null, nodes: Array<{ __typename?: 'SkillNode', id: string, title: string, step: number, orderInStep: number, quiz?: { __typename?: 'Quiz', id: string, title?: string | null, required: boolean, questions: Array<{ __typename?: 'QuizQuestion', id: string, prompt: string, type: QuestionType, options: Array<{ __typename?: 'QuizOption', id: string, text: string }> }> } | null }> }> } | null };
 
 export type PublicGetAllCoursesQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -5938,6 +6846,69 @@ export function useCreateCourseMutation(baseOptions?: ApolloReactHooks.MutationH
         return ApolloReactHooks.useMutation<CreateCourseMutation, CreateCourseMutationVariables>(CreateCourseDocument, options);
       }
 export type CreateCourseMutationHookResult = ReturnType<typeof useCreateCourseMutation>;
+export const StartNodeProgressDocument = gql`
+    mutation StartNodeProgress($nodeId: ID!) {
+  startNodeProgress(nodeId: $nodeId) {
+    id
+    status
+  }
+}
+    `;
+
+/**
+ * __useStartNodeProgressMutation__
+ *
+ * To run a mutation, you first call `useStartNodeProgressMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useStartNodeProgressMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [startNodeProgressMutation, { data, loading, error }] = useStartNodeProgressMutation({
+ *   variables: {
+ *      nodeId: // value for 'nodeId'
+ *   },
+ * });
+ */
+export function useStartNodeProgressMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<StartNodeProgressMutation, StartNodeProgressMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useMutation<StartNodeProgressMutation, StartNodeProgressMutationVariables>(StartNodeProgressDocument, options);
+      }
+export type StartNodeProgressMutationHookResult = ReturnType<typeof useStartNodeProgressMutation>;
+export const SubmitQuizAttemptDocument = gql`
+    mutation SubmitQuizAttempt($quizId: ID!, $answers: [String!]!) {
+  submitQuizAttempt(quizId: $quizId, answers: $answers) {
+    id
+    passed
+  }
+}
+    `;
+
+/**
+ * __useSubmitQuizAttemptMutation__
+ *
+ * To run a mutation, you first call `useSubmitQuizAttemptMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useSubmitQuizAttemptMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [submitQuizAttemptMutation, { data, loading, error }] = useSubmitQuizAttemptMutation({
+ *   variables: {
+ *      quizId: // value for 'quizId'
+ *      answers: // value for 'answers'
+ *   },
+ * });
+ */
+export function useSubmitQuizAttemptMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<SubmitQuizAttemptMutation, SubmitQuizAttemptMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useMutation<SubmitQuizAttemptMutation, SubmitQuizAttemptMutationVariables>(SubmitQuizAttemptDocument, options);
+      }
+export type SubmitQuizAttemptMutationHookResult = ReturnType<typeof useSubmitQuizAttemptMutation>;
 export const SyncCurrentUserDocument = gql`
     mutation SyncCurrentUser($name: String, $photoUrl: String) {
   syncCurrentUser(name: $name, photoUrl: $photoUrl) {
@@ -6023,6 +6994,26 @@ export const PublicCourseDocument = gql`
       id
       title
       description
+      nodes {
+        id
+        title
+        step
+        orderInStep
+        quiz {
+          id
+          title
+          required
+          questions {
+            id
+            prompt
+            type
+            options {
+              id
+              text
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Demo enablement for the cohort stakeholder demo — plus a fix for a build-breaking bug from #75 that surfaced while wiring this up.

## What's here

**1. `fix(api)`: implement XP/streak GraphQL objects (commit `d7ee8d0`) — please note**
#75 added the `UserXp` / `UserStreak` / `XpEvent` Prisma models + `User` relations, but never registered the GraphQL object types. The Pothos types are gitignored (regenerated on `prisma generate`), so on a **fresh `pnpm install`** the schema build throws `ObjectRef<UserXp> has not been implemented` — which breaks **`pnpm codegen` and the API server startup**. `tsc` doesn't catch it (runtime schema-build error), so it passed #75's CI. This commit registers the three models like every other model. It's cherry-pickable on its own if you want the fix to land independently.

**2. `feat`: demo enablement (commit `c4b128b`)**
- **Committable seed** — `pnpm db:seed:demo`: 5 courses (3 published incl. a full Organic Chemistry tree → nodes → lessons → quizzes with single/multiple/open questions + prerequisites; 2 drafts), plus learner progress. Authored by a synthetic user, so admins manage them normally.
- **Minimal learner Firebase login** — `AuthContext`, `LoginPage`, a real `ProtectedRoute`, and a `/login` route (mirrors the admin app). The cohort had deferred client auth; this is the smallest version that lets the authenticated learner flow work.
- **Learner deep flow** — `CourseDetailPage` wired to the live `publicCourse` API (extended to include nodes + quiz); new **`NodePage`** (`/courses/:id/nodes/:nodeId`) mounts the real `LessonViewer` (fires `startNodeProgress`, #80) and a **`QuizRunner`** that submits in the server's format and shows the graded result (#81).
- Regenerated `api-types`; added `docs/demo/cohort-demo-script.md`.

## Verification
Codegen + `tsc --noEmit` for **client / api / admin** all pass under Node 22 (the repo's `pnpm@10.17.1` needs Node ≥18.17). ⚠️ I verified locally because CI's `Lint & Type Check` job is effectively a no-op (`tsc … || true`) and `Build Frontend` can skip on client changes — worth fixing separately.

## Before the demo
1. `pnpm install` → `pnpm db:start` → `pnpm db:migrate:dev`
2. `pnpm db:seed:local-users` (creates `learner@local.dev` / `Local123!`) → `pnpm db:seed:demo`
3. `pnpm dev`; log into the learner app at `/login` as `learner@local.dev`.
4. **Do a full dry-run** end-to-end (login → course → lesson → quiz → carousel updates) — this stands up learner auth for the first time, so confirm Firebase env is set in `apps/client-frontend/.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
